### PR TITLE
Fix indentations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,14 +24,14 @@ end
 task :client do
 	require 'async/reactor'
 	require 'async/http/client'
-	
+
 	client = Async::HTTP::Client.new([
 		Async::IO::Endpoint.tcp('127.0.0.1', 9294, reuse_port: true)
 	], PROTOCOL)
-	
+
 	Async::Reactor.run do
 		response = client.get("/")
-		
+
 		puts response.inspect
 	end
 end
@@ -39,7 +39,7 @@ end
 task :wrk do
 	require 'async/reactor'
 	require 'async/http/server'
-	
+
 	app = lambda do |env|
 		[200, {}, ["Hello World"]]
 	end
@@ -59,7 +59,7 @@ task :wrk do
 	end
 
 	url = "http://127.0.0.1:9294/"
-	
+
 	connections = process_count
 	system("wrk", "-c", connections.to_s, "-d", "2", "-t", connections.to_s, url)
 

--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -15,15 +15,15 @@ Gem::Specification.new do |spec|
 	end
 	spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 	spec.require_paths = ["lib"]
-	
+
 	spec.add_dependency("async", "~> 1.1")
 	spec.add_dependency("async-io", "~> 1.0")
-	
+
 	spec.add_dependency("http-2", "~> 0.8")
 	spec.add_dependency("openssl")
-	
+
 	spec.add_development_dependency "async-rspec", "~> 1.1"
-	
+
 	spec.add_development_dependency "bundler", "~> 1.3"
 	spec.add_development_dependency "rspec", "~> 3.6"
 	spec.add_development_dependency "rake"

--- a/lib/async/http.rb
+++ b/lib/async/http.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,57 +23,57 @@ require 'async/io/endpoint'
 require_relative 'protocol'
 
 module Async
-	module HTTP
-		class Client
-			def initialize(endpoints, protocol_class = Protocol::HTTP11)
-				@endpoints = endpoints
-				
-				@protocol_class = protocol_class
-			end
-			
-			GET = 'GET'.freeze
-			HEAD = 'HEAD'.freeze
-			POST = 'POST'.freeze
-			
-			def get(path, *args)
-				connect do |protocol|
-					protocol.send_request(GET, path, *args)
-				end
-			end
-			
-			def head(path, *args)
-				connect do |protocol|
-					protocol.send_request(HEAD, path, *args)
-				end
-			end
-			
-			def post(path, *args)
-				connect do |protocol|
-					protocol.send_request(POST, path, *args)
-				end
-			end
-			
-			def send_request(*args)
-				connect do |protocol|
-					protocol.send_request(*args)
-				end
-			end
-			
-			private
-			
-			def connect
-				Async::IO::Endpoint.each(@endpoints) do |endpoint|
-					# puts "Connecting to #{address} on process #{Process.pid}"
-					
-					endpoint.connect do |peer|
-						stream = Async::IO::Stream.new(peer)
-						
-						# We only yield for first successful connection.
-						
-						return yield @protocol_class.new(stream, :client)
-					end
-				end
-			end
-		end
-	end
+  module HTTP
+    class Client
+      def initialize(endpoints, protocol_class = Protocol::HTTP11)
+        @endpoints = endpoints
+
+        @protocol_class = protocol_class
+      end
+
+      GET = 'GET'.freeze
+      HEAD = 'HEAD'.freeze
+      POST = 'POST'.freeze
+
+      def get(path, *args)
+        connect do |protocol|
+          protocol.send_request(GET, path, *args)
+        end
+      end
+
+      def head(path, *args)
+        connect do |protocol|
+          protocol.send_request(HEAD, path, *args)
+        end
+      end
+
+      def post(path, *args)
+        connect do |protocol|
+          protocol.send_request(POST, path, *args)
+        end
+      end
+
+      def send_request(*args)
+        connect do |protocol|
+          protocol.send_request(*args)
+        end
+      end
+
+      private
+
+      def connect
+        Async::IO::Endpoint.each(@endpoints) do |endpoint|
+          # puts "Connecting to #{address} on process #{Process.pid}"
+
+          endpoint.connect do |peer|
+            stream = Async::IO::Stream.new(peer)
+
+            # We only yield for first successful connection.
+
+            return yield @protocol_class.new(stream, :client)
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol.rb
+++ b/lib/async/http/protocol.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/async/http/protocol/http10.rb
+++ b/lib/async/http/protocol/http10.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,47 +24,47 @@ require_relative 'request'
 require_relative 'response'
 
 module Async
-	module HTTP
-		module Protocol
-			# Implements basic HTTP/1.1 request/response.
-			class HTTP10 < HTTP11
-				VERSION = "HTTP/1.0".freeze
-				
-				def version
-					VERSION
-				end
-				
-				def keep_alive?(headers)
-					headers[HTTP_CONNECTION] == KEEP_ALIVE
-				end
-				
-				# Server loop.
-				def receive_requests
-					while request = Request.new(*self.read_request)
-						status, headers, body = yield request
-						
-						write_response(request.version, status, headers, body)
-						
-						break unless keep_alive?(request.headers) && keep_alive?(headers)
-					end
-				end
-				
-				def write_body(body, chunked = true)
-					buffer = String.new
-					body.each{|chunk| buffer << chunk}
-						
-					@stream.write("Content-Length: #{buffer.bytesize}\r\n\r\n")
-					@stream.write(buffer)
-				end
-				
-				def read_body(headers)
-					if content_length = headers[HTTP_CONTENT_LENGTH]
-						return @stream.read(Integer(content_length))
-					# elsif !keep_alive?(headers)
-					# 	return @stream.read
-					end
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      # Implements basic HTTP/1.1 request/response.
+      class HTTP10 < HTTP11
+        VERSION = "HTTP/1.0".freeze
+
+        def version
+          VERSION
+        end
+
+        def keep_alive?(headers)
+          headers[HTTP_CONNECTION] == KEEP_ALIVE
+        end
+
+        # Server loop.
+        def receive_requests
+          while request = Request.new(*self.read_request)
+            status, headers, body = yield request
+
+            write_response(request.version, status, headers, body)
+
+            break unless keep_alive?(request.headers) && keep_alive?(headers)
+          end
+        end
+
+        def write_body(body, chunked = true)
+          buffer = String.new
+          body.each{|chunk| buffer << chunk}
+
+          @stream.write("Content-Length: #{buffer.bytesize}\r\n\r\n")
+          @stream.write(buffer)
+        end
+
+        def read_body(headers)
+          if content_length = headers[HTTP_CONTENT_LENGTH]
+            return @stream.read(Integer(content_length))
+            # elsif !keep_alive?(headers)
+            # 	return @stream.read
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/http11.rb
+++ b/lib/async/http/protocol/http11.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,161 +24,161 @@ require_relative 'request'
 require_relative 'response'
 
 module Async
-	module HTTP
-		module Protocol
-			# Implements basic HTTP/1.1 request/response.
-			class HTTP11 < Async::IO::Protocol::Line
-				HTTP_CONTENT_LENGTH = 'HTTP_CONTENT_LENGTH'.freeze
-				HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'.freeze
-				
-				CRLF = "\r\n".freeze
-				
-				def initialize(stream, mode)
-					super(stream, CRLF)
-				end
-				
-				HTTP_CONNECTION = 'HTTP_CONNECTION'.freeze
-				KEEP_ALIVE = 'keep-alive'.freeze
-				CLOSE = 'close'.freeze
-				
-				VERSION = "HTTP/1.1".freeze
-				
-				def version
-					VERSION
-				end
-				
-				def keep_alive?(headers)
-					headers[HTTP_CONNECTION] != CLOSE
-				end
-				
-				# Server loop.
-				def receive_requests(task: Task.current)
-					while true
-						request = Request.new(*read_request)
-						
-						status, headers, body = yield request
-						
-						write_response(request.version, status, headers, body)
-						
-						break unless keep_alive?(request.headers) && keep_alive?(headers)
-						
-						# This ensures we yield at least once every iteration of the loop and allow other fibers to execute.
-						task.yield
-					end
-				end
-				
-				# Client request.
-				def send_request(method, path, headers = {}, body = [])
-					write_request(method, path, version, headers, body)
-					
-					return Response.new(*read_response)
-				
-				rescue EOFError
-					return nil
-				end
-				
-				def write_request(method, path, version, headers, body)
-					@stream.write("#{method} #{path} #{version}\r\n")
-					write_headers(headers)
-					write_body(body)
-					
-					@stream.flush
-					
-					return true
-				end
-				
-				def read_response
-					version, status, reason = read_line.split(/\s+/, 3)
-					headers = read_headers
-					body = read_body(headers)
-					
-					return version, Integer(status), reason, headers, body
-				end
-				
-				def read_request
-					method, path, version = read_line.split(/\s+/, 3)
-					headers = read_headers
-					body = read_body(headers)
-					
-					return method, path, version, headers, body
-				end
-				
-				def write_response(version, status, headers, body)
-					@stream.write("#{version} #{status}\r\n")
-					write_headers(headers)
-					write_body(body)
-					
-					@stream.flush
-					
-					return true
-				end
-				
-				protected
-				
-				def write_headers(headers)
-					headers.each do |name, value|
-						@stream.write("#{name}: #{value}\r\n")
-					end
-				end
-				
-				def read_headers(headers = {})
-					# Parsing headers:
-					each_line do |line|
-						if line =~ /^([a-zA-Z\-]+):\s*(.+?)\s*$/
-							headers["HTTP_#{$1.tr('-', '_').upcase}"] = $2
-						else
-							break
-						end
-					end
-					
-					return headers
-				end
-				
-				def write_body(body, chunked = true)
-					if chunked
-						@stream.write("Transfer-Encoding: chunked\r\n\r\n")
-						
-						body.each do |chunk|
-							next if chunk.size == 0
-							
-							@stream.write("#{chunk.bytesize.to_s(16).upcase}\r\n")
-							@stream.write(chunk)
-							@stream.write(CRLF)
-						end
-						
-						@stream.write("0\r\n\r\n")
-					else
-						buffer = String.new
-						body.each{|chunk| buffer << chunk}
-						
-						@stream.write("Content-Length: #{chunk.bytesize}\r\n\r\n")
-						@stream.write(chunk)
-					end
-				end
-				
-				def read_body(headers)
-					if headers[HTTP_TRANSFER_ENCODING] == 'chunked'
-						buffer = Async::IO::BinaryString.new
-						
-						while true
-							size = read_line.to_i(16)
-							
-							if size == 0
-								read_line
-								break
-							end
-							
-							buffer << @stream.read(size)
-							
-							read_line # Consume the trailing CRLF
-						end
-						
-						return buffer
-					elsif content_length = headers[HTTP_CONTENT_LENGTH]
-						return @stream.read(Integer(content_length))
-					end
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      # Implements basic HTTP/1.1 request/response.
+      class HTTP11 < Async::IO::Protocol::Line
+        HTTP_CONTENT_LENGTH = 'HTTP_CONTENT_LENGTH'.freeze
+        HTTP_TRANSFER_ENCODING = 'HTTP_TRANSFER_ENCODING'.freeze
+
+        CRLF = "\r\n".freeze
+
+        def initialize(stream, mode)
+          super(stream, CRLF)
+        end
+
+        HTTP_CONNECTION = 'HTTP_CONNECTION'.freeze
+        KEEP_ALIVE = 'keep-alive'.freeze
+        CLOSE = 'close'.freeze
+
+        VERSION = "HTTP/1.1".freeze
+
+        def version
+          VERSION
+        end
+
+        def keep_alive?(headers)
+          headers[HTTP_CONNECTION] != CLOSE
+        end
+
+        # Server loop.
+        def receive_requests(task: Task.current)
+          while true
+            request = Request.new(*read_request)
+
+            status, headers, body = yield request
+
+            write_response(request.version, status, headers, body)
+
+            break unless keep_alive?(request.headers) && keep_alive?(headers)
+
+            # This ensures we yield at least once every iteration of the loop and allow other fibers to execute.
+            task.yield
+          end
+        end
+
+        # Client request.
+        def send_request(method, path, headers = {}, body = [])
+          write_request(method, path, version, headers, body)
+
+          return Response.new(*read_response)
+
+        rescue EOFError
+          return nil
+        end
+
+        def write_request(method, path, version, headers, body)
+          @stream.write("#{method} #{path} #{version}\r\n")
+          write_headers(headers)
+          write_body(body)
+
+          @stream.flush
+
+          return true
+        end
+
+        def read_response
+          version, status, reason = read_line.split(/\s+/, 3)
+          headers = read_headers
+          body = read_body(headers)
+
+          return version, Integer(status), reason, headers, body
+        end
+
+        def read_request
+          method, path, version = read_line.split(/\s+/, 3)
+          headers = read_headers
+          body = read_body(headers)
+
+          return method, path, version, headers, body
+        end
+
+        def write_response(version, status, headers, body)
+          @stream.write("#{version} #{status}\r\n")
+          write_headers(headers)
+          write_body(body)
+
+          @stream.flush
+
+          return true
+        end
+
+        protected
+
+        def write_headers(headers)
+          headers.each do |name, value|
+            @stream.write("#{name}: #{value}\r\n")
+          end
+        end
+
+        def read_headers(headers = {})
+          # Parsing headers:
+          each_line do |line|
+            if line =~ /^([a-zA-Z\-]+):\s*(.+?)\s*$/
+              headers["HTTP_#{$1.tr('-', '_').upcase}"] = $2
+            else
+              break
+            end
+          end
+
+          return headers
+        end
+
+        def write_body(body, chunked = true)
+          if chunked
+            @stream.write("Transfer-Encoding: chunked\r\n\r\n")
+
+            body.each do |chunk|
+              next if chunk.size == 0
+
+              @stream.write("#{chunk.bytesize.to_s(16).upcase}\r\n")
+              @stream.write(chunk)
+              @stream.write(CRLF)
+            end
+
+            @stream.write("0\r\n\r\n")
+          else
+            buffer = String.new
+            body.each{|chunk| buffer << chunk}
+
+            @stream.write("Content-Length: #{chunk.bytesize}\r\n\r\n")
+            @stream.write(chunk)
+          end
+        end
+
+        def read_body(headers)
+          if headers[HTTP_TRANSFER_ENCODING] == 'chunked'
+            buffer = Async::IO::BinaryString.new
+
+            while true
+              size = read_line.to_i(16)
+
+              if size == 0
+                read_line
+                break
+              end
+
+              buffer << @stream.read(size)
+
+              read_line # Consume the trailing CRLF
+            end
+
+            return buffer
+          elsif content_length = headers[HTTP_CONTENT_LENGTH]
+            return @stream.read(Integer(content_length))
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/http1x.rb
+++ b/lib/async/http/protocol/http1x.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,40 +22,40 @@ require_relative 'http10'
 require_relative 'http11'
 
 module Async
-	module HTTP
-		module Protocol
-			# A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
-			class HTTP1x < Async::IO::Protocol::Line
-				HANDLERS = {
-					"HTTP/1.0" => HTTP10,
-					"HTTP/1.1" => HTTP11,
-				}
-				
-				def initialize(stream, mode, handlers: HANDLERS)
-					super(stream, HTTP11::CRLF)
-					
-					@mode = mode
-					@handlers = handlers
-				end
-				
-				def create_handler(version)
-					if klass = @handlers[version]
-						klass.new(@stream, @mode)
-					else
-						raise RuntimeError, "Unsupported protocol version #{version}"
-					end
-				end
-				
-				def receive_requests(&block)
-					method, path, version = self.peek_line.split(/\s+/, 3)
-					
-					create_handler(version).receive_requests(&block)
-				end
-				
-				def send_request(request, &block)
-					create_handler(request.version).send_request(request, &block)
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      # A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
+      class HTTP1x < Async::IO::Protocol::Line
+        HANDLERS = {
+          "HTTP/1.0" => HTTP10,
+          "HTTP/1.1" => HTTP11,
+        }
+
+        def initialize(stream, mode, handlers: HANDLERS)
+          super(stream, HTTP11::CRLF)
+
+          @mode = mode
+          @handlers = handlers
+        end
+
+        def create_handler(version)
+          if klass = @handlers[version]
+            klass.new(@stream, @mode)
+          else
+            raise RuntimeError, "Unsupported protocol version #{version}"
+          end
+        end
+
+        def receive_requests(&block)
+          method, path, version = self.peek_line.split(/\s+/, 3)
+
+          create_handler(version).receive_requests(&block)
+        end
+
+        def send_request(request, &block)
+          create_handler(request.version).send_request(request, &block)
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/http2.rb
+++ b/lib/async/http/protocol/http2.rb
@@ -1,15 +1,15 @@
 # Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,114 +24,114 @@ require_relative 'response'
 require 'http/2'
 
 module Async
-	module HTTP
-		module Protocol
-			# A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
-			class HTTP2
-				def initialize(stream, mode)
-					@stream = stream
-					
-					case mode
-					when :server
-						@controller = ::HTTP2::Server.new
-					when :client
-						@controller = ::HTTP2::Client.new
-					else
-						raise ArgumentError.new("Unsupported mode #{mode}")
-					end
-					
-					@controller.on(:frame) do |data|
-						@stream.io.write data
-					end
-				end
-				
-				def receive_requests(&block)
-					# emits new streams opened by the client
-					@controller.on(:stream) do |stream|
-						request = Request.new
-						request.version = "HTTP/2.0"
-						request.headers = {}
-						
-						# stream.on(:active) { } # fires when stream transitions to open state
-						# stream.on(:close) { } # stream is closed by client and server
-						
-						stream.on(:headers) do |headers|
-							headers.each do |key, value|
-								if key == ':method'
-									request.method = value
-								elsif key == ':path'
-									request.path = value
-								else
-									request.headers[key] = value
-								end
-							end
-						end
-						
-						stream.on(:data) do |body|
-							request.body = body
-						end
-						
-						stream.on(:half_close) do
-							response = yield request
-							
-							# send response
-							stream.headers(':status' => response[0].to_s)
-							
-							stream.headers(response[1]) unless response[1].empty?
-							
-							response[2].each do |chunk|
-								stream.data(chunk, end_stream: false)
-							end
-							
-							stream.data("", end_stream: true)
-						end
-					end
-					
-					while data = @stream.io.read(1024)
-						@controller << data
-					end
-				end
-				
-				def send_request(method, path, headers = {}, body = [])
-					stream = @controller.new_stream
-					stream.headers({':method' => method, ':path' => path}.merge(headers), end_stream: false)
-					
-					body.each do |chunk|
-						stream.data(chunk, end_stream: false)
-					end
-					
-					stream.data("", end_stream: true)
-					
-					response = Response.new
-					response.version = "HTTP/2.0"
-					response.headers = {}
-					response.body = Async::IO::BinaryString.new
-					
-					stream.on(:headers) do |headers|
-						headers.each do |key, value|
-							if key == ':status'
-								response.status = value.to_i
-							elsif key == ':reason'
-								response.reason = value
-							else
-								response.headers[key] = value
-							end
-						end
-					end
-					
-					stream.on(:data) do |body|
-						response.body << body
-					end
-					
-					stream.on(:close) do
-						return response
-					end
-					
-					while data = @stream.io.read(1024)
-						@controller << data
-					end
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      # A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
+      class HTTP2
+        def initialize(stream, mode)
+          @stream = stream
+
+          case mode
+          when :server
+            @controller = ::HTTP2::Server.new
+          when :client
+            @controller = ::HTTP2::Client.new
+          else
+            raise ArgumentError.new("Unsupported mode #{mode}")
+          end
+
+          @controller.on(:frame) do |data|
+            @stream.io.write data
+          end
+        end
+
+        def receive_requests(&block)
+          # emits new streams opened by the client
+          @controller.on(:stream) do |stream|
+            request = Request.new
+            request.version = "HTTP/2.0"
+            request.headers = {}
+
+            # stream.on(:active) { } # fires when stream transitions to open state
+            # stream.on(:close) { } # stream is closed by client and server
+
+            stream.on(:headers) do |headers|
+              headers.each do |key, value|
+                if key == ':method'
+                  request.method = value
+                elsif key == ':path'
+                  request.path = value
+                else
+                  request.headers[key] = value
+                end
+              end
+            end
+
+            stream.on(:data) do |body|
+              request.body = body
+            end
+
+            stream.on(:half_close) do
+              response = yield request
+
+              # send response
+              stream.headers(':status' => response[0].to_s)
+
+              stream.headers(response[1]) unless response[1].empty?
+
+              response[2].each do |chunk|
+                stream.data(chunk, end_stream: false)
+              end
+
+              stream.data("", end_stream: true)
+            end
+          end
+
+          while data = @stream.io.read(1024)
+            @controller << data
+          end
+        end
+
+        def send_request(method, path, headers = {}, body = [])
+          stream = @controller.new_stream
+          stream.headers({':method' => method, ':path' => path}.merge(headers), end_stream: false)
+
+          body.each do |chunk|
+            stream.data(chunk, end_stream: false)
+          end
+
+          stream.data("", end_stream: true)
+
+          response = Response.new
+          response.version = "HTTP/2.0"
+          response.headers = {}
+          response.body = Async::IO::BinaryString.new
+
+          stream.on(:headers) do |headers|
+            headers.each do |key, value|
+              if key == ':status'
+                response.status = value.to_i
+              elsif key == ':reason'
+                response.reason = value
+              else
+                response.headers[key] = value
+              end
+            end
+          end
+
+          stream.on(:data) do |body|
+            response.body << body
+          end
+
+          stream.on(:close) do
+            return response
+          end
+
+          while data = @stream.io.read(1024)
+            @controller << data
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/https.rb
+++ b/lib/async/http/protocol/https.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,27 +23,27 @@ require_relative 'http11'
 require_relative 'http2'
 
 module Async
-	module HTTP
-		module Protocol
-			# A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
-			module HTTPS
-				HANDLERS = {
-					"http/1.0" => HTTP10,
-					"http/1.1" => HTTP11,
-					"h2" => HTTP2,
-				}
-				
-				def self.new(stream, mode)
-					# alpn_protocol is only available if openssl v1.0.2+
-					name = stream.io.alpn_protocol
-					
-					if name and protocol = HANDLERS[name]
-						return protocol.new(stream, mode)
-					else
-						return HTTP2.new(stream, mode)
-					end
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      # A server that supports both HTTP1.0 and HTTP1.1 semantics by detecting the version of the request.
+      module HTTPS
+        HANDLERS = {
+          "http/1.0" => HTTP10,
+          "http/1.1" => HTTP11,
+          "h2" => HTTP2,
+        }
+
+        def self.new(stream, mode)
+          # alpn_protocol is only available if openssl v1.0.2+
+          name = stream.io.alpn_protocol
+
+          if name and protocol = HANDLERS[name]
+            return protocol.new(stream, mode)
+          else
+            return HTTP2.new(stream, mode)
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/request.rb
+++ b/lib/async/http/protocol/request.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,13 +19,13 @@
 # THE SOFTWARE.
 
 module Async
-	module HTTP
-		module Protocol
-			class Request < Struct.new(:method, :path, :version, :headers, :body)
-				def read
-					@body
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      class Request < Struct.new(:method, :path, :version, :headers, :body)
+        def read
+          @body
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/protocol/response.rb
+++ b/lib/async/http/protocol/response.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,25 +19,25 @@
 # THE SOFTWARE.
 
 module Async
-	module HTTP
-		module Protocol
-			class Response < Struct.new(:version, :status, :reason, :headers, :body)
-				def continue?
-					status == 100
-				end
-				
-				def success?
-					status >= 200 && status < 300
-				end
-				
-				def redirection?
-					status >= 300 && status < 400
-				end
-				
-				def failure?
-					status >= 400 && status < 600
-				end
-			end
-		end
-	end
+  module HTTP
+    module Protocol
+      class Response < Struct.new(:version, :status, :reason, :headers, :body)
+        def continue?
+          status == 100
+        end
+
+        def success?
+          status >= 200 && status < 300
+        end
+
+        def redirection?
+          status >= 300 && status < 400
+        end
+
+        def failure?
+          status >= 400 && status < 600
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/server.rb
+++ b/lib/async/http/server.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,44 +23,44 @@ require 'async/io/endpoint'
 require_relative 'protocol'
 
 module Async
-	module HTTP
-		class Server
-			def initialize(endpoints, protocol_class = Protocol::HTTP1x)
-				@endpoints = endpoints
-				@protocol_class = protocol_class
-			end
-			
-			def handle_request(request, peer, address)
-				[200, {"Content-Type" => "text/plain"}, ["Hello World"]]
-			end
-			
-			def accept(peer, address)
-				stream = Async::IO::Stream.new(peer)
-				protocol = @protocol_class.new(stream, :server)
-				
-				# puts "Opening session on child pid #{Process.pid}"
-				
-				hijack = catch(:hijack) do
-					protocol.receive_requests do |request|
-						handle_request(request, peer, address)
-					end
-				end
+  module HTTP
+    class Server
+      def initialize(endpoints, protocol_class = Protocol::HTTP1x)
+        @endpoints = endpoints
+        @protocol_class = protocol_class
+      end
 
-				if hijack
-					hijack.call
-				end
-			rescue EOFError, Errno::ECONNRESET, Errno::EPIPE
-				# Sometimes client will disconnect without completing a result or reading the entire buffer.
-				return nil
-			end
-			
-			def run
-				Async::IO::Endpoint.each(@endpoints) do |endpoint|
-					# puts "Binding to #{endpoint} on process #{Process.pid}"
-					
-					endpoint.accept(&self.method(:accept))
-				end
-			end
-		end
-	end
+      def handle_request(request, peer, address)
+        [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+      end
+
+      def accept(peer, address)
+        stream = Async::IO::Stream.new(peer)
+        protocol = @protocol_class.new(stream, :server)
+
+        # puts "Opening session on child pid #{Process.pid}"
+
+        hijack = catch(:hijack) do
+          protocol.receive_requests do |request|
+            handle_request(request, peer, address)
+          end
+        end
+
+        if hijack
+          hijack.call
+        end
+      rescue EOFError, Errno::ECONNRESET, Errno::EPIPE
+        # Sometimes client will disconnect without completing a result or reading the entire buffer.
+        return nil
+      end
+
+      def run
+        Async::IO::Endpoint.each(@endpoints) do |endpoint|
+          # puts "Binding to #{endpoint} on process #{Process.pid}"
+
+          endpoint.accept(&self.method(:accept))
+        end
+      end
+    end
+  end
 end

--- a/lib/async/http/url_endpoint.rb
+++ b/lib/async/http/url_endpoint.rb
@@ -1,15 +1,15 @@
 # Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,61 +22,61 @@ require 'async/io/endpoint'
 require 'async/io/ssl_socket'
 
 module Async
-	module HTTP
-		class URLEndpoint < Async::IO::Endpoint
-			def self.parse(string, **options)
-				self.new(URI.parse(string), **options)
-			end
-			
-			def address
-				endpoint.address
-			end
-			
-			def secure?
-				['https', 'wss'].include?(specification.scheme)
-			end
-			
-			def default_port
-				secure? ? 443 : 80
-			end
-			
-			def port
-				specification.port || default_port
-			end
-			
-			def hostname
-				specification.hostname
-			end
-			
-			def ssl_context
-				options[:ssl_context] || ::OpenSSL::SSL::SSLContext.new.tap do |context|
-					context.set_params
-				end
-			end
-			
-			def endpoint
-				unless defined? @endpoint
-					@endpoint = Async::IO::Endpoint.tcp(hostname, port)
-					
-					if secure?
-						# Wrap it in SSL:
-						@endpoint = Async::IO::SecureEndpoint.new(@endpoint,
-							ssl_context: ssl_context,
-							hostname: self.hostname
-						)
-					end
-				end
-				
-				return @endpoint
-			end
-			
-			def bind(*args, &block)
-				endpoint.bind(*args, &block)
-			end
-			
-			def connect(*args, &block)
-				endpoint.connect(*args, &block)
-			end
-		end
-	end
+  module HTTP
+    class URLEndpoint < Async::IO::Endpoint
+      def self.parse(string, **options)
+        self.new(URI.parse(string), **options)
+      end
+
+      def address
+        endpoint.address
+      end
+
+      def secure?
+        ['https', 'wss'].include?(specification.scheme)
+      end
+
+      def default_port
+        secure? ? 443 : 80
+      end
+
+      def port
+        specification.port || default_port
+      end
+
+      def hostname
+        specification.hostname
+      end
+
+      def ssl_context
+        options[:ssl_context] || ::OpenSSL::SSL::SSLContext.new.tap do |context|
+          context.set_params
+        end
+      end
+
+      def endpoint
+        unless defined? @endpoint
+          @endpoint = Async::IO::Endpoint.tcp(hostname, port)
+
+          if secure?
+            # Wrap it in SSL:
+            @endpoint = Async::IO::SecureEndpoint.new(@endpoint,
+                                                      ssl_context: ssl_context,
+                                                      hostname: self.hostname
+                                                      )
+          end
+        end
+
+        return @endpoint
+      end
+
+      def bind(*args, &block)
+        endpoint.bind(*args, &block)
+      end
+
+      def connect(*args, &block)
+        endpoint.connect(*args, &block)
+      end
+    end
+  end
 end

--- a/lib/async/http/version.rb
+++ b/lib/async/http/version.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 module Async
-	module HTTP
-		VERSION = "0.7.0"
-	end
+  module HTTP
+    VERSION = "0.7.0"
+  end
 end

--- a/spec/async/http/client_spec.rb
+++ b/spec/async/http/client_spec.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,18 +26,18 @@ RSpec.describe Async::HTTP::Client do
 	let(:server_addresses) {[
 		Async::IO::Endpoint.tcp('127.0.0.1', 9294, reuse_port: true)
 	]}
-	
+
 	it "client can get resource" do
 		server = Async::HTTP::Server.new(server_addresses)
 		client = Async::HTTP::Client.new(server_addresses)
-		
+
 		Async::Reactor.run do |task|
 			server_task = task.async do
 				server.run
 			end
-			
+
 			response = client.get("/")
-			
+
 			expect(response).to be_success
 			server_task.stop
 		end

--- a/spec/async/http/performance_spec.rb
+++ b/spec/async/http/performance_spec.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,16 +29,16 @@ RSpec.describe Async::HTTP::Server do
 	let(:server_addresses) {[
 		Async::IO::Endpoint.tcp('127.0.0.1', 9294, reuse_port: true)
 	]}
-	
+
 	let(:server_url) {"http://127.0.0.1:9294/"}
-	
+
 	let(:concurrency) {Etc.nprocessors rescue 2}
-	
+
 	# TODO making this higher causes issues in connect - what's the issue?
 	let(:repeats) {10000}
-	
+
 	let(:client) {Async::HTTP::Client.new(server_addresses)}
-	
+
 	describe "simple response" do
 		it "runs quickly" do
 			server = Async::HTTP::Server.new(server_addresses)
@@ -50,7 +50,7 @@ RSpec.describe Async::HTTP::Server do
 					end
 				end
 			end
-			
+
 			# duration = Benchmark.realtime do
 			# 	Async::Reactor.run do |task|
 			# 		concurrency.times do
@@ -63,17 +63,17 @@ RSpec.describe Async::HTTP::Server do
 			# 		end
 			# 	end
 			# end
-			# 	
+			#
 			# puts "#{concurrency*repeats} requests in #{duration}s: #{(concurrency*repeats)/duration}req/s"
-			
+
 			if ab = `which ab`.chomp!
 				system(ab, "-n", (concurrency*repeats).to_s, "-c", concurrency.to_s, server_url)
 			end
-			
+
 			if wrk = `which wrk`.chomp!
 				system(wrk, "-c", concurrency.to_s, "-d", "10", "-t", concurrency.to_s, server_url)
 			end
-			
+
 			pids.each do |pid|
 				Process.kill(:KILL, pid)
 				Process.wait pid

--- a/spec/async/http/protocol/http11_spec.rb
+++ b/spec/async/http/protocol/http11_spec.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,14 +23,14 @@ require 'async/http/protocol/http11'
 RSpec.describe Async::HTTP::Protocol::HTTP11 do
 	let(:stream) {Async::IO::Stream.new(io)}
 	subject {described_class.new(stream, :server)}
-	
+
 	describe "simple request" do
 		let(:request) {"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"}
 		let(:io) {StringIO.new(request)}
-	
+
 		it "reads request" do
 			method, url, version, headers, body = subject.read_request
-			
+
 			expect(method).to be == 'GET'
 			expect(url).to be == '/'
 			expect(version).to be == 'HTTP/1.1'
@@ -38,14 +38,14 @@ RSpec.describe Async::HTTP::Protocol::HTTP11 do
 			expect(body).to be nil
 		end
 	end
-	
+
 	describe "simple request with body" do
 		let(:request) {"GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 11\r\n\r\nHello World"}
 		let(:io) {StringIO.new(request)}
-	
+
 		it "reads request" do
 			method, url, version, headers, body = subject.read_request
-			
+
 			expect(method).to be == 'GET'
 			expect(url).to be == '/'
 			expect(version).to be == 'HTTP/1.1'

--- a/spec/async/http/ssl_spec.rb
+++ b/spec/async/http/ssl_spec.rb
@@ -10,16 +10,16 @@ require 'async/rspec/ssl'
 RSpec.describe Async::HTTP::Server do
 	include_context Async::RSpec::Reactor
 	include_context Async::RSpec::SSL::ValidCertificate
-	
+
 	describe "application layer protocol negotiation" do
 		let(:server_context) do
 			OpenSSL::SSL::SSLContext.new.tap do |context|
 				context.cert = certificate
-				
+
 				context.alpn_select_cb = lambda do |protocols|
 					protocols.last
 				end
-				
+
 				context.key = key
 			end
 		end
@@ -27,29 +27,29 @@ RSpec.describe Async::HTTP::Server do
 		let(:client_context) do
 			OpenSSL::SSL::SSLContext.new.tap do |context|
 				context.cert_store = certificate_store
-				
+
 				context.alpn_protocols = ["http/1.0", "http/1.1", "h2"]
-				
+
 				context.verify_mode = OpenSSL::SSL::VERIFY_PEER
 			end
 		end
-		
+
 		# Shared port for localhost network tests.
 		let(:endpoint) {Async::IO::Endpoint.tcp("localhost", 6779, reuse_port: true)}
 		let(:server_endpoint) {Async::IO::SecureEndpoint.new(endpoint, ssl_context: server_context)}
 		let(:client_endpoint) {Async::IO::SecureEndpoint.new(endpoint, ssl_context: client_context)}
-		
+
 		it "client can get a resource via https" do
 			server = Async::HTTP::Server.new([server_endpoint], Async::HTTP::Protocol::HTTPS)
 			client = Async::HTTP::Client.new([client_endpoint], Async::HTTP::Protocol::HTTPS)
-			
+
 			Async::Reactor.run do |task|
 				server_task = task.async do
 					server.run
 				end
-				
+
 				response = client.get("/")
-				
+
 				expect(response).to be_success
 				expect(response.body).to be == "Hello World"
 				server_task.stop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,11 @@
 if ENV['COVERAGE'] || ENV['TRAVIS']
 	begin
 		require 'simplecov'
-		
+
 		SimpleCov.start do
 			add_filter "/spec/"
 		end
-		
+
 		if ENV['TRAVIS']
 			require 'coveralls'
 			Coveralls.wear!


### PR DESCRIPTION
I notice indentations are off while browsing the codebase. This PR fixes it.

Same for [other](https://github.com/socketry/rubydns) [repos](https://github.com/socketry/async-io) [under](https://github.com/socketry/async-postgres/blob/master/lib/async/postgres/pool.rb) [socketry](https://github.com/socketry/async/), maybe editor needs some configurations.

Let me know if you need any help.