### PR TITLE
Allow numbers in HTTP header names

### DIFF
--- a/lib/async/http/protocol/http11.rb
+++ b/lib/async/http/protocol/http11.rb
@@ -241,7 +241,7 @@ module Async
 					fields = []
 					
 					each_line do |line|
-						if line =~ /^([a-zA-Z\-]+):\s*(.+?)\s*$/
+						if line =~ /^([a-zA-Z\-\d]+):\s*(.+?)\s*$/
 							fields << [$1, $2]
 						else
 							break

--- a/spec/async/http/protocol/http11_spec.rb
+++ b/spec/async/http/protocol/http11_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP11, timeout: 2 do
 		subject {described_class.new(stream)}
 
 		describe "simple request" do
-			let(:request) {"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: */*\r\n\r\n"}
+			let(:request) {"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: */*\r\nHeader-0: value 1\r\n"}
 			let(:io) {StringIO.new(request)}
 		
 			it "reads request" do
@@ -39,7 +39,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP11, timeout: 2 do
 				expect(method).to be == 'GET'
 				expect(url).to be == '/'
 				expect(version).to be == 'HTTP/1.1'
-				expect(headers).to be == {'accept' => ['*/*']}
+				expect(headers).to be == {'accept' => ['*/*'], "header-0" => ["value 1"]}
 				expect(body).to be nil
 			end
 		end


### PR DESCRIPTION
When requesting an AWS S3 object, some response headers that are returned have numbers in them. So, it seems that numbers are valid in HTTP header names, therefore we allow them.

Fixes #8