### PR TITLE
Open File in binary mode in HTTP::Body::File

### DIFF
--- a/lib/async/http/body/file.rb
+++ b/lib/async/http/body/file.rb
@@ -28,7 +28,7 @@ module Async
 				BLOCK_SIZE = Async::IO::Stream::BLOCK_SIZE
 				
 				def self.open(path, *args)
-					self.new(::File.open(path), *args)
+					self.new(::File.open(path, "rb"), *args)
 				end
 				
 				def initialize(file, range = nil, block_size: BLOCK_SIZE)


### PR DESCRIPTION
It's generally safer to open the file in binary mode, because then C won't try to do any conversions between representations of newlines depending on the OS, it will just retrieve bytes as is. See Avdi's RubyTapas for more details: https://www.rubytapas.com/2016/12/14/ruby-code-on-windows/