### PR TITLE
fix Async::HTTP::Body::Buffered.wrap when body is a string

### DIFF
--- a/lib/async/http/body/buffered.rb
+++ b/lib/async/http/body/buffered.rb
@@ -32,6 +32,8 @@ module Async
 						return body
 					elsif body.is_a? Array
 						return self.new(body)
+					elsif body.is_a?(String)
+						return self.new([body])
 					elsif body
 						return self.for(body)
 					end

--- a/spec/async/http/body/buffered_spec.rb
+++ b/spec/async/http/body/buffered_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Async::HTTP::Body::Buffered do
 				expect(subject.read).to be == "World"
 			end
 		end
+
+		context "when body is a String" do
+			let(:body) {"Hello World"}
+
+			it "returns instance initialized with the array" do
+				expect(subject).to be_an_instance_of(described_class)
+			end
+		end
 	end
 	
 	describe "#length" do


### PR DESCRIPTION
while using sentry with async faraday adapter I've encountored a bug
```ruby
> Async { Raven.capture { 1/0 } }.wait.result  
Sending event f6b69fac47c042939038275a610f9ac3 to Sentry
Raven HTTP Transport connecting to https://sentry.io
Unable to record event with remote Sentry server (NoMethodError - undefined method `each' for #<String:0x00007f32f02545c0>):
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/async-http-0.38.1/lib/async/http/body/buffered.rb:43:in `for'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/async-http-0.38.1/lib/async/http/body/buffered.rb:36:in `wrap'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/async-http-0.38.1/lib/async/http/request.rb:57:in `[]'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/async-http-0.38.1/lib/async/http/middleware.rb:37:in `block (2 levels) in <module:Methods>'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/async-http-faraday-0.2.0/lib/async/http/faraday/adapter.rb:34:in `call'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/faraday-0.15.4/lib/faraday/response.rb:8:in `call'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/faraday-0.15.4/lib/faraday/connection.rb:175:in `post'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/sentry-raven-2.9.0/lib/raven/transports/http.rb:24:in `send_event'
/home/senid/.rvm/gems/ruby-2.5.1@async_rails/gems/sentry-raven-2.9.0/lib/raven/client.rb:43:in `send_event'
Failed to submit event: ZeroDivisionError: divided by 0
```

didn't see any reason why body can't be a `String`