### PR TITLE
Fix `require` in code sample in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ require 'async/http/server'
 require 'async/http/client'
 require 'async/reactor'
 require 'async/http/endpoint'
-require 'async/http/response'
+require 'async/http/protocol/response'
 
 endpoint = Async::HTTP::Endpoint.parse('http://127.0.0.1:9294')
 


### PR DESCRIPTION
One of the code samples doesn't run because of an incorrect `require`.