### PR TITLE
Fixed Endpoint#path

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -125,7 +125,7 @@ module Async
 			
 			# Return the path and query components of the given URL.
 			def path
-				buffer = @url.path || "/"
+				buffer = @url.path.dup || "/"
 				
 				if query = @url.query
 					buffer = "#{buffer}?#{query}"


### PR DESCRIPTION
Calling endpoint.path had the side-effect of mutating the original @url.path to add query params, so calling it multiple times would re-add the query params every time, resulting in paths like `/example?foo=bar&bam=baz?foo=bar&bam=baz`. 

Fixed by duping the `@url.path` for the buffer var.