### PR TITLE
Change RelativeLocation to raise TooManyRedirects.

### DIFF
--- a/lib/async/http/relative_location.rb
+++ b/lib/async/http/relative_location.rb
@@ -26,6 +26,9 @@ require 'protocol/http/middleware'
 
 module Async
 	module HTTP
+		class TooManyRedirects < StandardError
+		end
+
 		# A client wrapper which transparently handles both relative and absolute redirects to a given maximum number of hops.
 		class RelativeLocation < ::Protocol::HTTP::Middleware
 			DEFAULT_METHOD = GET
@@ -69,7 +72,7 @@ module Async
 					end
 				end
 				
-				raise ArgumentError, "Redirected #{hops} times, exceeded maximum!"
+				raise TooManyRedirects, "Redirected #{hops} times, exceeded maximum!"
 			end
 		end
 	end

--- a/spec/async/http/relative_location_spec.rb
+++ b/spec/async/http/relative_location_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Async::HTTP::RelativeLocation do
 			it 'should fail with maximum redirects' do
 				expect{
 					response = subject.get('/forever')
-				}.to raise_error(ArgumentError, /maximum/)
+				}.to raise_error(Async::HTTP::TooManyRedirects, /maximum/)
 			end
 		end
 		


### PR DESCRIPTION
`ArgumentError` isn't the right error to raise when there are too many redirects because
it indicates that the arguments passed to a method call are wrong.

This is a breaking change. It changes the contract with callers.
