### PR TITLE
Use raise, not throw.

### DIFF
--- a/lib/async/http/protocol/https.rb
+++ b/lib/async/http/protocol/https.rb
@@ -66,7 +66,7 @@ module Async
 					if protocol = HANDLERS[name]
 						return protocol
 					else
-						throw ArgumentError.new("Could not determine protocol for connection (#{name.inspect}).")
+						raise ArgumentError, "Could not determine protocol for connection (#{name.inspect})."
 					end
 				end
 				


### PR DESCRIPTION
Small fix: should use `raise` instead of `throw` when an error occurs.

There was no test to update.
