### PR TITLE
Fix 204 No Content server response

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -91,10 +91,10 @@ module Async
 								else
 									head = request.head?
 									
+									write_body(request.version, body, head, trailers)
+
 									request = nil unless body
 									response = nil
-									
-									write_body(request.version, body, head, trailers)
 								end
 							else
 								# If the request failed to generate a response, it was an internal server error:

--- a/spec/async/http/protocol/shared_examples.rb
+++ b/spec/async/http/protocol/shared_examples.rb
@@ -85,6 +85,18 @@ RSpec.shared_examples_for Async::HTTP::Protocol do
 			expect(client.get("/", {}).read).to be == "Hello World"
 		end
 	end
+
+	context 'empty body' do
+		let(:server) do
+			Async::HTTP::Server.for(endpoint, protocol) do |request|
+				Protocol::HTTP::Response[204]
+			end
+		end
+
+		it 'properly handles no content responses' do
+			expect(client.get("/", {}).read).to be_nil
+		end
+	end
 	
 	context 'with trailers', if: described_class.bidirectional? do
 		let(:server) do


### PR DESCRIPTION
This PR fixes bug introduced in 5f63e9c: if server tries to respond with `204 No Content` response that does not contain body, following exception is raised:
```
NoMethodError: undefined method `version' for nil:NilClass
  /app/lib/async/http/protocol/http1/server.rb:97 in `each'
  /app/lib/async/http/server.rb:53 in `accept'
  /app/vendor/ruby/2.6.0/gems/async-io-1.29.0/lib/async/io/server.rb:32 in `block in accept_each'
  /app/vendor/ruby/2.6.0/gems/async-io-1.29.0/lib/async/io/socket.rb:73 in `block in accept'
  /app/vendor/ruby/2.6.0/gems/async-1.25.2/lib/async/task.rb:258 in `block in make_fiber'
```