### PR TITLE
Allow using custom endpoints for Async::HTTP::Internet

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -33,6 +33,16 @@ module Async
 				)
 			end
 			
+			# Coerce the given object into an endpoint.
+			# @parameter url [String | Endpoint] The URL or endpoint to convert.
+			def self.[](url)
+				if url.is_a?(Endpoint)
+					return url
+				else
+					Endpoint.parse(url.to_str)
+				end
+			end
+			
 			# @option scheme [String] the scheme to use, overrides the URL scheme.
 			# @option hostname [String] the hostname to connect to (or bind to), overrides the URL hostname (used for SNI).
 			# @option port [Integer] the port to bind to, overrides the URL port.

--- a/lib/async/http/internet.rb
+++ b/lib/async/http/internet.rb
@@ -39,7 +39,7 @@ module Async
 			# @parameter headers [Hash | Protocol::HTTP::Headers] The headers to send with the request.
 			# @parameter body [String | Protocol::HTTP::Body] The body to send with the request.
 			def call(method, url, headers = nil, body = nil)
-				endpoint = Endpoint.parse(url)
+				endpoint = Endpoint[url]
 				client = self.client_for(endpoint)
 				
 				body = Body::Buffered.wrap(body)
@@ -60,7 +60,7 @@ module Async
 			
 			::Protocol::HTTP::Methods.each do |name, verb|
 				define_method(verb.downcase) do |url, headers = nil, body = nil|
-					self.call(verb, url.to_str, headers, body)
+					self.call(verb, url, headers, body)
 				end
 			end
 			

--- a/test/async/http/internet.rb
+++ b/test/async/http/internet.rb
@@ -33,4 +33,18 @@ describe Async::HTTP::Internet do
 		expect(response).to be(:success?)
 		expect{JSON.parse(response.read)}.not.to raise_exception
 	end
+	
+	it 'can fetch remote website when given custom endpoint instead of url' do
+		ssl_context = OpenSSL::SSL::SSLContext.new
+		ssl_context.set_params(verify_mode: OpenSSL::SSL::VERIFY_NONE)
+		
+		# example of site with invalid certificate that will fail to be fetched without custom SSL options
+		endpoint = Async::HTTP::Endpoint.parse('https://expired.badssl.com', ssl_context: ssl_context)
+		
+		response = internet.get(endpoint, headers)
+		
+		expect(response).to be(:success?)
+	ensure
+		response&.close
+	end
 end


### PR DESCRIPTION
This PR introduces changes that allow passing custom `Async::HTTP::Endpoint` to `Async::HTTP::Internet`. This could be useful for example when we need to provide custom SSL options to requests.