### PR TITLE
Fix Async::HTTP::Body::Pipe race condition bug

### DIFF
--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -22,6 +22,9 @@
 
 require_relative 'writable'
 
+require 'async/io/socket'
+require 'async/io/stream'
+
 module Async
 	module HTTP
 		module Body
@@ -37,7 +40,7 @@ module Async
 					@tail = tail
 					
 					@reader = nil
-					@writer = nil
+					@writer = :uninitialized
 					
 					task.async(&self.method(:reader))
 					task.async(&self.method(:writer))

--- a/spec/async/http/body/pipe_spec.rb
+++ b/spec/async/http/body/pipe_spec.rb
@@ -1,0 +1,39 @@
+# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'async/http/body/pipe'
+
+RSpec.describe Async::HTTP::Body::Pipe do
+	include_context Async::RSpec::Reactor
+	
+	describe "object lifecycle" do
+		let(:input) do
+			Async::HTTP::Body::Writable.new.tap do |body|
+				body.write("<body>Hello world</body>")
+				body.close
+			end
+		end
+		
+		it "doesn't raise" do
+			pipe = described_class.new(input)
+			pipe.close
+		end
+	end
+end


### PR DESCRIPTION
Hi,

after using `Async::HTTP::Body::Pipe` as pointed out in #55 I started getting these exceptions:

```
 0.05s    error: Async::Task [oid=0x8c] [pid=87174] [2020-06-04 16:25:19 +0200]
               |   IOError: closed stream
               |   → <internal:io> 63
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-io-1.30.0/lib/async/io/generic.rb:216 in `async_send'
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-io-1.30.0/lib/async/io/generic.rb:69 in `block in wrap_blocking_method'
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-io-1.30.0/lib/async/io/stream.rb:261 in `fill_read_buffer'
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-io-1.30.0/lib/async/io/stream.rb:99 in `read_partial'
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-http-0.52.4/lib/async/http/body/pipe.rb:88 in `writer'
               |     /Users/bruno/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/async-1.26.1/lib/async/task.rb:258 in `block in make_fiber'
```

The code to reproduce:

```ruby
require 'async'
require 'async/http/body/pipe'

Async do
  body = Async::HTTP::Body::Writable.new()
  body.write('<body>Hello world</body>')
  body.close

  pipe = Async::HTTP::Body::Pipe.new(body)
  pipe.close
end
```

The above is a simple, but contrived example. I was getting the same error when making many requests with a code similar to example from #55.

Here's the explanation why I think that happens:

1. The `#reader` async task started in `#initialized` method runs completely synchronously. The `@input.read` from `#reader` method will run without ever blocking.
2. The `ensure` block in `#reader` method will mistakenly close the `@head` socket before the `#writer` method ever started.

https://github.com/socketry/async-http/blob/0e17f9086f73a3d55f907aaf6349e278de61fd44/lib/async/http/body/pipe.rb#L75

3.  When the `#writer` task starts, it will error on this line (because `@head` is closed):

https://github.com/socketry/async-http/blob/0e17f9086f73a3d55f907aaf6349e278de61fd44/lib/async/http/body/pipe.rb#L85

I tried writing a spec and implementing a fix - but I'm not happy with either of them.

- The spec, when applied to current `master`, doesn't actually fail. The spec throws an error, but it gets "lost" in a "background fiber". Any suggestions? I'd be glad to improve this.
- The fix itself does the trick, but is hacky. Another (also hacky) solution would be to NOT define `@writer` in the `#initialize` method. The last line of the `#reader` method could then be `@head.close if defined(@writer) && @writer.nil?`. Both approaches make the code less clear, so any pointers are welcome!

Thanks
