### PR TITLE
Add specs to replicate missing auth.

### DIFF
--- a/spec/async/http/proxy_spec.rb
+++ b/spec/async/http/proxy_spec.rb
@@ -135,6 +135,10 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 				
 				host, port = request.path.split(":", 2)
 				endpoint = Async::IO::Endpoint.tcp(host, port)
+
+				unless authorization_lambda.call(request)
+					next Protocol::HTTP::Response[407, {}, []]
+				end
 				
 				Async.logger.debug(self) {"Making connection to #{endpoint}..."}
 				
@@ -176,6 +180,8 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 				end
 			end
 		end
+
+		let(:authorization_lambda) { ->(request) { true } }
 		
 		it 'can get insecure website' do
 			endpoint = Async::HTTP::Endpoint.parse("http://www.google.com")
@@ -204,6 +210,40 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 			expect(response.read).to_not be_empty
 			
 			proxy_client.close
+		end
+
+		context 'authorization header required' do
+			let(:authorization_lambda) do
+				->(request) {request.headers['proxy-authorization'] == 'supersecretpassword' }
+			end
+
+			context 'request includes headers' do
+				let(:headers) { [['Proxy-Authorization', 'supersecretpassword']] }
+
+				it 'succeeds' do
+					endpoint = Async::HTTP::Endpoint.parse("https://www.google.com")
+					proxy_client = client.proxied_client(endpoint, headers)
+			
+					response = proxy_client.get('/search')
+
+					expect(response).to_not be_failure
+					expect(response.read).to_not be_empty
+					proxy_client.close
+				end
+			end
+
+			context 'request does not include headers' do
+				it 'does not succeed' do
+					endpoint = Async::HTTP::Endpoint.parse("https://www.google.com")
+					proxy_client = client.proxied_client(endpoint)
+			
+					response = proxy_client.get('/search')
+
+					expect(response.read).to be_empty
+					expect(response.status).to be 407
+					proxy_client.close
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
As discussed in Slack, adds some specs to test the "proxy server requires auth, no auth given" case.

After running locally, I'm confirming that the happy path auth succeeds, missing auth gets a broken pipe.