### PR TITLE
Add timeout usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,29 @@ Async do
 end
 ```
 
+### Timeouts
+
+Here's a basic example with a timeout:
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'async/http/internet'
+
+Async do |task|
+	internet = Async::HTTP::Internet.new
+	
+	# Request will timeout after 2 seconds
+	task.with_timeout(2) do
+		response = internet.get "https://httpbin.org/delay/10"
+	end
+rescue Async::TimeoutError
+	puts "The request timed out"
+ensure
+	internet&.close
+end
+```
+
 ## Performance
 
 On a 4-core 8-thread i7, running `ab` which uses discrete (non-keep-alive) connections:


### PR DESCRIPTION
Hi,

I first wanted to open an issue with a question: "how to set an internet request timeout?". After investigating for some time, I think I got it right so I'm submitting this PR so other's don't have to spend the time.

Here's a more nuanced question:

Is it better to set a timeout directly on [Async::HTTP::Endpoint](https://github.com/bruno-/async-http/blob/timeout_example/lib/async/http/endpoint.rb) instance? Or it's just fine to wrap `Async::HTTP::Internet` requests in a `task.with_timeout` block? Are there any advantages to using low-level `Async::HTTP::Endpoint` directly?
