### PR TITLE
Make Body::Pipe background tasks transient

### DIFF
--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -20,6 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'async/io/socket'
+require 'async/io/stream'
+
 require_relative 'writable'
 
 module Async
@@ -39,8 +42,8 @@ module Async
 					@reader = nil
 					@writer = nil
 					
-					task.async(&self.method(:reader))
-					task.async(&self.method(:writer))
+					task.async(transient: true, &self.method(:reader))
+					task.async(transient: true, &self.method(:writer))
 				end
 				
 				def to_io

--- a/spec/async/http/body/pipe_spec.rb
+++ b/spec/async/http/body/pipe_spec.rb
@@ -1,0 +1,83 @@
+# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'async'
+require 'async/http/body/pipe'
+require 'async/http/body/writable'
+
+RSpec.describe Async::HTTP::Body::Pipe do
+	let(:input) { Async::HTTP::Body::Writable.new }
+	let(:pipe) { described_class.new(input) }
+
+	let(:data) { 'Hello World!' }
+
+	describe '#to_io' do
+		include_context Async::RSpec::Reactor
+
+		let(:io) { pipe.to_io }
+
+		before do
+			Async::Task.current.async do |task| # input writer task
+				first, second = data.split(' ')
+				input.write("#{first} ")
+				task.sleep(input_write_duration) if input_write_duration > 0
+				input.write(second)
+				input.close
+			end
+		end
+
+		after { io.close }
+
+		shared_examples :returns_io_socket do
+			it 'returns an io socket' do
+				expect(io).to be_a(Async::IO::Socket)
+				expect(io.read).to eq data
+			end
+		end
+
+		context 'when reading blocks' do
+			let(:input_write_duration) { 0.01 }
+
+			include_examples :returns_io_socket
+		end
+
+		context 'when reading does not block' do
+			let(:input_write_duration) { 0 }
+
+			# Passes but raises 'IOError: closed stream' in the background, see
+			# explanation in https://github.com/socketry/async-http/pull/56
+			include_examples :returns_io_socket
+		end
+	end
+
+	describe 'going out of reactor scope' do
+		context 'when pipe is closed' do
+			it 'finishes' do
+				Async { pipe.close }
+			end
+		end
+
+		context 'when pipe is not closed' do
+			it 'finishes' do # ensures pipe background tasks are transient
+				Async { pipe }
+			end
+		end
+	end
+end


### PR DESCRIPTION
I watched [your video on transient tasks](https://www.youtube.com/watch?v=tENWCqJXhoI) and realized we have a potential bug when `Body::Pipe` class is used standalone (outside `Proxy` class).

The problem is simple to reproduce and is covered with specs.

```ruby
require 'async'
require 'async/http/body/pipe'
require 'async/http/body/writable'

# Body::Pipe dependencies, also fixed in this PR
require 'async/io/socket'
require 'async/io/stream'

Async do
  # pipe that is not closed will hang forever
  Async::HTTP::Body::Pipe.new(Async::HTTP::Body::Writable.new)
end
```

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
