### PR TITLE
Don't show HTTP2 GoawayError in terminal

### DIFF
--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -107,6 +107,13 @@ module Async
 								end
 							rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Async::Wrapper::Cancelled
 								# Ignore.
+							rescue ::Protocol::HTTP2::GoawayError => error
+								# Error is raised if a response is actively reading from the
+								# connection. The connection is silently closed if GOAWAY is
+								# received outside the request/response cycle.
+								if @reader
+									self.close(error)
+								end
 							ensure
 								# Don't call #close twice.
 								if @reader


### PR DESCRIPTION
Here's a minimal example that illustrates the problem:

```ruby
require "async"
require "async/http/internet"

Async do |task|
  internet = Async::HTTP::Internet.new
  puts internet.get("https://economist.com/").status # 301, HTTP2 connection
  task.sleep 10 # Protocol::HTTP2::GoawayError raised in ~5 seconds as the server closes the connection.

  puts "This code unexpectedly runs because the exception was only raised in the background."
  puts "The internet object is also fine."
  puts internet.get("https://economist.com/").status # 301
end
```
The problem is `Protocol::HTTP2::GoawayError` + its backtrace show up in the terminal whenever the remote server benevolently closes idle connection outside the request-response cycle.
The premise is: this scenario is not an error. It's equivalent to HTTP1 connection close after the request is done.

The current behavior looks like a scary issue (red characters in the terminal, stack trace etc), but it's not. In fact, `async-http` handles things great and there's nothing a user should do (like `rescue`, retry or similar).

I have not run an extensive research, but I think all the sites running http2 using amazon cloudfront or Incapsula/[imperva](https://www.imperva.com) do benevolently close idle http2 connections after 4 minutes. This maybe applies to other CDNs. Heres an example for site running on Incapsula CDN:

```ruby
require "async"
require "async/http/internet"

Async do |task|
  internet = Async::HTTP::Internet.new
  puts internet.get("https://www.proofpoint.com").read&.length
  task.sleep 250 # Protocol::HTTP2::GoawayError raised in 4 minutes
end
```

The proposal: don't show background task exception for `Protocol::HTTP2::GoawayError`.
I will add specs and improve the code if the idea is green-lighted.

## Types of Changes

- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
