### PR TITLE
Track HTTP/1 connection state so that we can avoid reusing it.

### DIFF
--- a/examples/race/client.rb
+++ b/examples/race/client.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require 'async'
+require_relative '../../lib/async/http/internet'
+
+Async.logger.fatal!
+
+Async do |task|
+	internet = Async::HTTP::Internet.new
+	tasks = []
+	
+	100.times do
+		tasks << task.async {
+			loop do
+				response = internet.get('http://127.0.0.1:8080/something/special')
+				r = response.body.join
+				if r.include?('nothing')
+					p ['something', r]
+				end
+			end
+		}
+	end
+	
+	100.times do
+		tasks << task.async {
+			loop do
+				response = internet.get('http://127.0.0.1:8080/nothing/to/worry')
+				r = response.body.join
+				if r.include?('something')
+					p ['nothing', r]
+				end
+			end
+		}
+	end
+	
+	tasks.each do |t|
+		task.sleep 0.1
+		t.stop
+	end
+end

--- a/examples/race/server.rb
+++ b/examples/race/server.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'async'
+require 'async/http/server'
+require 'async/http/endpoint'
+require 'async/http/protocol/response'
+
+endpoint = Async::HTTP::Endpoint.parse('http://127.0.0.1:8080')
+
+app = lambda do |request|
+	Protocol::HTTP::Response[200, {}, [request.path[1..-1]]]
+end
+
+server = Async::HTTP::Server.new(app, endpoint)
+
+Async do |task|
+	server.run
+end

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -33,6 +33,7 @@ module Async
 					def initialize(stream, version)
 						super(stream)
 						
+						@ready = true
 						@version = version
 					end
 					
@@ -68,11 +69,11 @@ module Async
 					
 					# Can we use this connection to make requests?
 					def viable?
-						@stream&.connected?
+						@ready && @stream&.connected?
 					end
 					
 					def reusable?
-						@persistent && @stream && !@stream.closed?
+						@ready && @persistent && @stream && !@stream.closed?
 					end
 				end
 			end


### PR DESCRIPTION
## Description

It is possible for the HTTP/1 client to get out of sync if an exception is raised during writing the request and before finishing reading the response line. If this happens, subsequent requests will potentially read the previous response body.

### Types of Changes

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
