### PR TITLE
Don't ignore network errors.

### DIFF
--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -49,8 +49,6 @@ module Async
 					
 					def read_line?
 						@stream.read_until(CRLF)
-					rescue Errno::ECONNRESET
-						return nil
 					end
 					
 					def read_line


### PR DESCRIPTION
## Description

As discussed in https://github.com/socketry/async-http/pull/70

I don't believe `read_line?` should ignore errors.

### Types of Changes

- Bug fix.

### Testing

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
