### PR TITLE
Avoid "shadowing outer local variable - task"

### DIFF
--- a/lib/async/http/protocol/http2/server.rb
+++ b/lib/async/http/protocol/http2/server.rb
@@ -65,8 +65,8 @@ module Async
 						task.annotate("Reading #{version} requests for #{self.class}.")
 						
 						# It's possible the connection has died before we get here...
-						@requests&.async do |task, request|
-							task.annotate("Incoming request: #{request.method} #{request.path.inspect}.")
+						@requests&.async do |t, request|
+							t.annotate("Incoming request: #{request.method} #{request.path.inspect}.")
 							
 							@count += 1
 							


### PR DESCRIPTION
## Description

This PR attempts to avoid a Ruby warning being emitted

    gems/async-http-0.56.3/lib/async/http/protocol/http2/server.rb:68: warning: shadowing outer local variable - task



### Types of Changes

- Maintenance.

### Testing

...