### PR TITLE
Endpoint.for should normalize URL

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -43,7 +43,7 @@ module Async
 				uri_klass = URI.scheme_list[scheme.upcase] || URI::HTTP
 				
 				self.new(
-					uri_klass.new(scheme, nil, hostname, nil, nil, nil, nil, nil, nil),
+					uri_klass.new(scheme, nil, hostname, nil, nil, nil, nil, nil, nil).normalize,
 					**options
 				)
 			end

--- a/spec/async/http/endpoint_spec.rb
+++ b/spec/async/http/endpoint_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Async::HTTP::Endpoint do
 	
 	describe '.for' do
 		context Async::HTTP::Endpoint.for("http", "localhost") do
-			it {is_expected.to have_attributes(scheme: "http", hostname: "localhost")}
+			it {is_expected.to have_attributes(scheme: "http", hostname: "localhost", path: "/")}
 			it {is_expected.to_not be_secure}
 		end
 	end


### PR DESCRIPTION
When using Endpoint.parse, the generated URL is normalized before
passing to the constructor, resulting in a `path` attribute of `/` by default.

When using Endpoint.for, the path is left as an empty String, which causes
issues in some web servers. To make the behaviour consistent, Endpoint.for
will normalize as well.