### PR TITLE
Allow `Endpoint.for` to accept optional path

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -37,13 +37,13 @@ module Async
 				return self.new(url, endpoint, **options)
 			end
 			
-			# Construct an endpoint with a specified scheme, hostname, and options.
-			def self.for(scheme, hostname, **options)
+			# Construct an endpoint with a specified scheme, hostname, optional path, and options.
+			def self.for(scheme, hostname, path = "/", **options)
 				# TODO: Consider using URI.for once it becomes available:
 				uri_klass = URI.scheme_list[scheme.upcase] || URI::HTTP
 				
 				self.new(
-					uri_klass.new(scheme, nil, hostname, nil, nil, nil, nil, nil, nil).normalize,
+					uri_klass.new(scheme, nil, hostname, nil, nil, path, nil, nil, nil).normalize,
 					**options
 				)
 			end

--- a/spec/async/http/endpoint_spec.rb
+++ b/spec/async/http/endpoint_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe Async::HTTP::Endpoint do
 			it {is_expected.to have_attributes(scheme: "http", hostname: "localhost", path: "/")}
 			it {is_expected.to_not be_secure}
 		end
+
+		context Async::HTTP::Endpoint.for("http", "localhost", "/foo") do
+			it {is_expected.to have_attributes(scheme: "http", hostname: "localhost", path: "/foo")}
+		end
 	end
 	
 	describe '#secure?' do


### PR DESCRIPTION
## Description

The `Endpoint.for` method can accept an optional path, overriding the default of `/`.

Continuation of #85 

### Types of Changes

- New feature.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
