### PR TITLE
Reduce output size of Async::HTTP::Client#inspect

### DIFF
--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -138,7 +138,11 @@ module Async
 					@pool.release(connection) if connection
 				end
 			end
-			
+
+			def inspect
+				"#<#{self.class} authority=#{@authority.inspect}>"
+			end
+
 			Traces::Provider(self) do
 				def call(request)
 					attributes = {


### PR DESCRIPTION
Some tests are failing in CI, and the logs are very hard to debug since the output is lengthy (the log archive was 110mb zip file). This PR addresses this issue by trimming down the inspect output of `Async::HTTP::Client` to make it human readable.