### PR TITLE
Fix test compatibility with new fiber scheduler.

### DIFF
--- a/lib/async/http/relative_location.rb
+++ b/lib/async/http/relative_location.rb
@@ -28,11 +28,11 @@ module Async
 	module HTTP
 		class TooManyRedirects < StandardError
 		end
-
+		
 		# A client wrapper which transparently handles both relative and absolute redirects to a given maximum number of hops.
 		class RelativeLocation < ::Protocol::HTTP::Middleware
 			DEFAULT_METHOD = GET
-
+			
 			# maximum_hops is the max number of redirects. Set to 0 to allow 1 request with no redirects.
 			def initialize(app, maximum_hops = 3)
 				super(app)
@@ -51,7 +51,7 @@ module Async
 				
 				while hops <= @maximum_hops
 					response = super(request)
-
+					
 					if response.redirection?
 						hops += 1
 						response.finish

--- a/spec/async/http/client_spec.rb
+++ b/spec/async/http/client_spec.rb
@@ -31,6 +31,7 @@ require 'protocol/http/accept_encoding'
 RSpec.describe Async::HTTP::Client, timeout: 5 do
 	describe Async::HTTP::Protocol::HTTP1 do
 		include_context Async::HTTP::Server
+		let(:protocol) {described_class}
 		
 		it "client can get resource" do
 			response = client.get("/")

--- a/spec/async/http/protocol/http11/desync_spec.rb
+++ b/spec/async/http/protocol/http11/desync_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP11, timeout: 30 do
 	include_context Async::HTTP::Server
 	
 	let(:server) do
-		Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+		Async::HTTP::Server.for(@bound_endpoint) do |request|
 			Protocol::HTTP::Response[200, {}, [request.path]]
 		end
 	end

--- a/spec/async/http/protocol/http11_spec.rb
+++ b/spec/async/http/protocol/http11_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP11, timeout: 2 do
 		include_context Async::HTTP::Server
 		
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				Protocol::HTTP::Response[200, {}, ["Hello", "World"]]
 			end
 		end
@@ -50,7 +50,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP11, timeout: 2 do
 		include_context Async::HTTP::Server
 		
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				peer = request.hijack!
 				
 				peer.write(

--- a/spec/async/http/protocol/http2_spec.rb
+++ b/spec/async/http/protocol/http2_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe Async::HTTP::Protocol::HTTP2, timeout: 2 do
 		include_context Async::HTTP::Server
 		
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				Protocol::HTTP::Response[200, request.headers, ["Authority: #{request.authority.inspect}"]]
 			end
 		end
 		
 		# We specify nil for the authority - it won't be sent.
-		let!(:client) {Async::HTTP::Client.new(endpoint, protocol: protocol, scheme: endpoint.scheme, authority: nil)}
+		let!(:client) {Async::HTTP::Client.new(endpoint, authority: nil)}
 		
 		it "should not send :authority header if host header is present" do
 			response = client.post("/", [['host', 'foo']])
@@ -76,7 +76,7 @@ RSpec.describe Async::HTTP::Protocol::HTTP2, timeout: 2 do
 		let(:notification) {Async::Notification.new}
 		
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				body = Async::HTTP::Body::Writable.new
 				
 				reactor.async do |task|

--- a/spec/async/http/proxy_spec.rb
+++ b/spec/async/http/proxy_spec.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 	
 	context 'CONNECT' do
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
 					chunk = stream.read
 					stream.close_read
@@ -77,7 +77,7 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 	
 	context 'echo server' do
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				expect(request.path).to be == "localhost:1"
 				
 				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
@@ -130,7 +130,7 @@ RSpec.shared_examples_for Async::HTTP::Proxy do
 	
 	context 'proxied client' do
 		let(:server) do
-			Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+			Async::HTTP::Server.for(@bound_endpoint) do |request|
 				expect(request.method).to be == "CONNECT"
 				
 				unless authorization_lambda.call(request)

--- a/spec/async/http/retry_spec.rb
+++ b/spec/async/http/retry_spec.rb
@@ -25,13 +25,13 @@ require 'async/http/endpoint'
 
 RSpec.describe 'consistent retry behaviour' do
 	include_context Async::HTTP::Server
+	let(:protocol) {Async::HTTP::Protocol::HTTP1}
 	
 	let(:delay) {0.1}
 	let(:retries) {2}
-	let(:protocol) {Async::HTTP::Protocol::HTTP1}
 	
 	let(:server) do
-		Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+		Async::HTTP::Server.for(@bound_endpoint) do |request|
 			Async::Task.current.sleep(delay)
 			Protocol::HTTP::Response[200, {}, []]
 		end

--- a/spec/async/http/server_context.rb
+++ b/spec/async/http/server_context.rb
@@ -21,25 +21,31 @@
 require 'async/http/server'
 require 'async/http/client'
 require 'async/http/endpoint'
-
-# Console.logger.level = Logger::DEBUG
+require 'async/io/shared_endpoint'
 
 RSpec.shared_context Async::HTTP::Server do
 	include_context Async::RSpec::Reactor
 	
 	let(:protocol) {described_class}
-	let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:9294', timeout: 0.8, reuse_port: true)}
+	let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:9294', timeout: 0.8, reuse_port: true, protocol: protocol)}
 	
 	let(:retries) {1}
 	
 	let(:server) do
-		Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+		Async::HTTP::Server.for(@bound_endpoint) do |request|
 			Protocol::HTTP::Response[200, {}, []]
 		end
 	end
 	
 	before do
-		@client = Async::HTTP::Client.new(endpoint, protocol: protocol, retries: retries)
+		@client = Async::HTTP::Client.new(endpoint, protocol: endpoint.protocol, retries: retries)
+		
+		# We bind the endpoint before running the server so that we know incoming connections will be accepted:
+		@bound_endpoint = Async::IO::SharedEndpoint.bound(endpoint)
+		
+		# I feel a dedicated class might be better than this hack:
+		allow(@bound_endpoint).to receive(:protocol).and_return(endpoint.protocol)
+		allow(@bound_endpoint).to receive(:scheme).and_return(endpoint.scheme)
 		
 		@server_task = Async do
 			server.run
@@ -49,8 +55,8 @@ RSpec.shared_context Async::HTTP::Server do
 	after do
 		@client.close
 		@server_task.stop
+		@bound_endpoint.close
 	end
 	
 	let(:client) {@client}
-	let(:server_task) {@server_task}
 end

--- a/spec/async/http/statistics_spec.rb
+++ b/spec/async/http/statistics_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Async::HTTP::Statistics, timeout: 5 do
 	let(:protocol) {Async::HTTP::Protocol::HTTP1}
 	
 	let(:server) do
-		Async::HTTP::Server.for(endpoint, protocol: protocol) do |request|
+		Async::HTTP::Server.for(@bound_endpoint) do |request|
 			statistics = described_class.start
 			
 			response = Protocol::HTTP::Response[200, {}, ["Hello ", "World!"]]


### PR DESCRIPTION
The fibers scheduler introduces more context switching points which made some specs a bit flaky. This PR fixes those cases and improves the general structure of some related tests.

### Types of Changes

- Maintenance.
