### PR TITLE
Allow `Async::HTTP::Internet` methods to accept `URI::HTTP` objects.

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -39,7 +39,7 @@ module Async
 				if url.is_a?(Endpoint)
 					return url
 				else
-					Endpoint.parse(url.to_str)
+					Endpoint.parse(url.to_s)
 				end
 			end
 			

--- a/test/async/http/internet.rb
+++ b/test/async/http/internet.rb
@@ -23,6 +23,15 @@ describe Async::HTTP::Internet do
 		response.close
 	end
 	
+	it "can accept URI::HTTP objects" do
+		uri = URI.parse("https://www.codeotaku.com/index")
+		response = internet.get(uri, headers)
+		
+		expect(response).to be(:success?)
+	ensure
+		response&.close
+	end
+	
 	let(:sample) {{"hello" => "world"}}
 	let(:body) {[JSON.dump(sample)]}
 	


### PR DESCRIPTION
`URI::HTTP` objects do not define a `to_str` method, so call `to_s` on the `uri` instead.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
