### PR TITLE
Update body spec to use server context.

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -177,6 +177,10 @@ module Async
 				@endpoint ||= build_endpoint
 			end
 			
+			def endpoint=(endpoint)
+				@endpoint = build_endpoint(endpoint)
+			end
+			
 			def bind(*arguments, &block)
 				endpoint.bind(*arguments, &block)
 			end

--- a/spec/async/http/body_spec.rb
+++ b/spec/async/http/body_spec.rb
@@ -11,109 +11,100 @@ require 'async/http/endpoint'
 
 require 'async/io/ssl_socket'
 
-require 'async/rspec/reactor'
+require_relative 'server_context'
 
 require 'localhost/authority'
 
 RSpec.shared_examples Async::HTTP::Body do
 	let(:client) {Async::HTTP::Client.new(client_endpoint, protocol: described_class)}
 	
-	it "can stream requests" do
-		server = Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
-			input = request.body
-			output = Async::HTTP::Body::Writable.new
-			
-			Async::Task.current.async do |task|
-				input.each do |chunk|
-					output.write(chunk.reverse)
+	context 'with echo server' do
+		let(:server) do
+			Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
+				input = request.body
+				output = Async::HTTP::Body::Writable.new
+				
+				Async::Task.current.async do |task|
+					input.each do |chunk|
+						output.write(chunk.reverse)
+					end
+					
+					output.close
 				end
 				
+				Protocol::HTTP::Response[200, [], output]
+			end	
+		end
+		
+		it "can stream requests" do
+			output = Async::HTTP::Body::Writable.new
+			
+			reactor.async do |task|
+				output.write("Hello World!")
 				output.close
 			end
 			
-			Protocol::HTTP::Response[200, [], output]
+			response = client.post("/", {}, output)
+			
+			expect(response).to be_success
+			expect(response.read).to be == "!dlroW olleH"
 		end
-		
-		server_task = reactor.async do
-			server.run
-		end
-		
-		output = Async::HTTP::Body::Writable.new
-		
-		reactor.async do |task|
-			output.write("Hello World!")
-			output.close
-		end
-		
-		response = client.post("/", {}, output)
-		
-		expect(response).to be_success
-		expect(response.read).to be == "!dlroW olleH"
-		
-		server_task.stop
-		client.close
 	end
 	
-	it "can stream response" do
-		notification = Async::Notification.new
+	context "with streaming server" do
+		let(:notification) {Async::Notification.new}
 		
-		server = Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
-			body = Async::HTTP::Body::Writable.new
-			
-			Async::Task.current.async do |task|
-				10.times do |i|
-					body.write("#{i}")
-					notification.wait
+		let(:server) do
+			Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
+				body = Async::HTTP::Body::Writable.new
+				
+				Async::Task.current.async do |task|
+					10.times do |i|
+						body.write("#{i}")
+						notification.wait
+					end
+					
+					body.close
 				end
 				
-				body.close
+				Protocol::HTTP::Response[200, {}, body]
 			end
+		end
+		
+		it "can stream response" do
+			response = client.get("/")
 			
-			Protocol::HTTP::Response[200, {}, body]
-		end
-		
-		server_task = reactor.async do
-			server.run
-		end
-		
-		response = client.get("/")
-		
-		expect(response).to be_success
-		
-		j = 0
-		# This validates interleaving
-		response.body.each do |line|
-			expect(line.to_i).to be == j
-			j += 1
+			expect(response).to be_success
 			
-			notification.signal
-		end
-		
-		server_task.stop
-		client.close
+			j = 0
+			# This validates interleaving
+			response.body.each do |line|
+				expect(line.to_i).to be == j
+				j += 1
+				
+				notification.signal
+			end
+		end	
 	end
 end
 
 RSpec.describe Async::HTTP::Protocol::HTTP1 do
-	include_context Async::RSpec::Reactor
-	
-	let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:9296', reuse_port: true)}
-	let(:client_endpoint) {endpoint}
-	let(:server_endpoint) {endpoint}
+	include_context Async::HTTP::Server
 	
 	it_should_behave_like Async::HTTP::Body
 end
 
 RSpec.describe Async::HTTP::Protocol::HTTPS do
-	include_context Async::RSpec::Reactor
+	include_context Async::HTTP::Server
+	
 	let(:authority) {Localhost::Authority.new}
 	
 	let(:server_context) {authority.server_context}
 	let(:client_context) {authority.client_context}
 	
 	# Shared port for localhost network tests.
-	let(:server_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9296", ssl_context: server_context)}
-	let(:client_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9296", ssl_context: client_context)}
+	let(:server_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9299", ssl_context: server_context, reuse_port: true)}
+	let(:client_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9299", ssl_context: client_context, reuse_port: true)}
 	
 	it_should_behave_like Async::HTTP::Body
 end

--- a/spec/async/http/body_spec.rb
+++ b/spec/async/http/body_spec.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples Async::HTTP::Body do
 	
 	context 'with echo server' do
 		let(:server) do
-			Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
+			Async::HTTP::Server.for(@bound_endpoint, protocol: described_class) do |request|
 				input = request.body
 				output = Async::HTTP::Body::Writable.new
 				
@@ -55,7 +55,7 @@ RSpec.shared_examples Async::HTTP::Body do
 		let(:notification) {Async::Notification.new}
 		
 		let(:server) do
-			Async::HTTP::Server.for(server_endpoint, protocol: described_class) do |request|
+			Async::HTTP::Server.for(@bound_endpoint, protocol: described_class) do |request|
 				body = Async::HTTP::Body::Writable.new
 				
 				Async::Task.current.async do |task|
@@ -103,8 +103,8 @@ RSpec.describe Async::HTTP::Protocol::HTTPS do
 	let(:client_context) {authority.client_context}
 	
 	# Shared port for localhost network tests.
-	let(:server_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9299", ssl_context: server_context, reuse_port: true)}
-	let(:client_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:9299", ssl_context: client_context, reuse_port: true)}
+	let(:server_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:0", ssl_context: server_context, reuse_port: true)}
+	let(:client_endpoint) {Async::HTTP::Endpoint.parse("https://localhost:0", ssl_context: client_context, reuse_port: true)}
 	
 	it_should_behave_like Async::HTTP::Body
 end

--- a/spec/async/http/protocol/shared_examples.rb
+++ b/spec/async/http/protocol/shared_examples.rb
@@ -443,7 +443,7 @@ RSpec.shared_examples_for Async::HTTP::Protocol do
 	end
 	
 	context 'slow server' do
-		let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:9294', reuse_port: true, timeout: 0.1)}
+		let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:0', reuse_port: true, timeout: 0.1)}
 		
 		let(:server) do
 			Async::HTTP::Server.for(@bound_endpoint) do |request|

--- a/spec/async/http/server_context.rb
+++ b/spec/async/http/server_context.rb
@@ -14,6 +14,9 @@ RSpec.shared_context Async::HTTP::Server do
 	let(:protocol) {described_class}
 	let(:endpoint) {Async::HTTP::Endpoint.parse('http://127.0.0.1:9294', timeout: 0.8, reuse_port: true, protocol: protocol)}
 	
+	let(:server_endpoint) {endpoint}
+	let(:client_endpoint) {endpoint}
+	
 	let(:retries) {1}
 	
 	let(:server) do
@@ -24,17 +27,17 @@ RSpec.shared_context Async::HTTP::Server do
 	
 	before do
 		# We bind the endpoint before running the server so that we know incoming connections will be accepted:
-		@bound_endpoint = Async::IO::SharedEndpoint.bound(endpoint)
+		@bound_endpoint = Async::IO::SharedEndpoint.bound(server_endpoint)
 		
 		# I feel a dedicated class might be better than this hack:
-		allow(@bound_endpoint).to receive(:protocol).and_return(endpoint.protocol)
-		allow(@bound_endpoint).to receive(:scheme).and_return(endpoint.scheme)
+		allow(@bound_endpoint).to receive(:protocol).and_return(server_endpoint.protocol)
+		allow(@bound_endpoint).to receive(:scheme).and_return(server_endpoint.scheme)
 		
 		@server_task = Async do
 			server.run
 		end
 		
-		@client = Async::HTTP::Client.new(endpoint, protocol: endpoint.protocol, retries: retries)
+		@client = Async::HTTP::Client.new(client_endpoint, protocol: endpoint.protocol, retries: retries)
 	end
 	
 	after do


### PR DESCRIPTION
The server context ensures that a bound endpoint is used for the server, which avoids any race between creating the server and connecting with the client.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
