### PR TITLE
Prefer `Traces.trace`.

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "protocol-http", "~> 0.24.0"
 	spec.add_dependency "protocol-http1", "~> 0.15.0"
 	spec.add_dependency "protocol-http2", "~> 0.15.0"
-	spec.add_dependency "traces", ">= 0.8.0"
+	spec.add_dependency "traces", ">= 0.10.0"
 	
 	spec.add_development_dependency "async-container", "~> 0.14"
 	spec.add_development_dependency "async-rspec", "~> 1.10"

--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -144,8 +144,8 @@ module Async
 						attributes['http.request.length'] = length
 					end
 					
-					trace('async.http.client.call', attributes: attributes) do |span|
-						if context = self.trace_context
+					Traces.trace('async.http.client.call', attributes: attributes) do |span|
+						if context = Traces.trace_context
 							request.headers['traceparent'] = context.to_s
 							# request.headers['tracestate'] = context.state
 						end

--- a/lib/async/http/server.rb
+++ b/lib/async/http/server.rb
@@ -61,7 +61,7 @@ module Async
 			Traces::Provider(self) do
 				def call(request)
 					if trace_parent = request.headers['traceparent']
-						self.trace_context = Traces::Context.parse(trace_parent.join, request.headers['tracestate'], remote: true)
+						Traces.trace_context = Traces::Context.parse(trace_parent.join, request.headers['tracestate'], remote: true)
 					end
 					
 					attributes = {
@@ -80,7 +80,7 @@ module Async
 						attributes['http.protocol'] = protocol
 					end
 					
-					trace('async.http.server.call', resource: "#{request.method} #{request.path}", attributes: attributes) do |span|
+					Traces.trace('async.http.server.call', resource: "#{request.method} #{request.path}", attributes: attributes) do |span|
 						super.tap do |response|
 							if status = response&.status
 								span['http.status_code'] = status


### PR DESCRIPTION
The `traces` gem was updated with a "easier to use" interface, `Traces.trace`. This also prepares us to avoid clobbering `Protocol::HTTP::Methods#trace`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
