### PR TITLE
Add auto-detection of HTTP1 vs HTTP2 for inbound http:// connections

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async", ">= 2.10.2"
 	spec.add_dependency "async-pool", ">= 0.6.1"
 	spec.add_dependency "io-endpoint", "~> 0.10.0"
-	spec.add_dependency "io-stream", "~> 0.3.0"
+	spec.add_dependency "io-stream", "~> 0.4.0"
 	spec.add_dependency "protocol-http", "~> 0.26.0"
 	spec.add_dependency "protocol-http1", "~> 0.19.0"
 	spec.add_dependency "protocol-http2", "~> 0.17.0"

--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -8,7 +8,7 @@ require 'io/endpoint'
 require 'io/endpoint/host_endpoint'
 require 'io/endpoint/ssl_endpoint'
 
-require_relative 'protocol/http1'
+require_relative 'protocol/http'
 require_relative 'protocol/https'
 
 module Async

--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -84,7 +84,7 @@ module Async
 					if secure?
 						Protocol::HTTPS
 					else
-						Protocol::HTTP1
+						Protocol::HTTP
 					end
 				end
 			end

--- a/lib/async/http/protocol/http.rb
+++ b/lib/async/http/protocol/http.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Thomas Morgan.
+
+require_relative 'http1'
+require_relative 'http2'
+
+module Async
+	module HTTP
+		module Protocol
+			# HTTP is an http:// server that auto-selects HTTP/1.1 or HTTP/2 by detecting the HTTP/2
+			# connection preface.
+			module HTTP
+				HTTP2_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+				HTTP2_PREFACE_SIZE = HTTP2_PREFACE.bytesize
+				
+				def self.protocol_for(stream)
+					# Detect HTTP/2 connection preface
+					# https://www.rfc-editor.org/rfc/rfc9113.html#section-3.4
+					preface = stream.peek do |read_buffer|
+						if read_buffer.bytesize >= HTTP2_PREFACE_SIZE
+							break read_buffer[0, HTTP2_PREFACE_SIZE]
+						elsif read_buffer.bytesize > 0
+							# If partial read_buffer already doesn't match, no need to wait for more bytes.
+							break read_buffer unless HTTP2_PREFACE[read_buffer]
+						end
+					end
+					
+					if preface == HTTP2_PREFACE
+						HTTP2
+					else
+						HTTP1
+					end
+				end
+				
+				# Only inbound connections can detect HTTP1 vs HTTP2 for http://.
+				# Outbound connections default to HTTP1.
+				def self.client(peer, **options)
+					HTTP1.client(peer, **options)
+				end
+				
+				def self.server(peer, **options)
+					stream = ::IO::Stream(peer)
+					
+					return protocol_for(stream).server(stream, **options)
+				end
+				
+				def self.names
+					["h2", "http/1.1", "http/1.0"]
+				end
+			end
+		end
+	end
+end

--- a/lib/async/http/protocol/http1.rb
+++ b/lib/async/http/protocol/http1.rb
@@ -2,11 +2,12 @@
 
 # Released under the MIT License.
 # Copyright, 2017-2024, by Samuel Williams.
+# Copyright, 2023, by Thomas Morgan.
 
 require_relative 'http1/client'
 require_relative 'http1/server'
 
-require 'io/stream/buffered'
+require 'io/stream'
 
 module Async
 	module HTTP
@@ -23,13 +24,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http10.rb
+++ b/lib/async/http/protocol/http10.rb
@@ -2,6 +2,7 @@
 
 # Released under the MIT License.
 # Copyright, 2017-2024, by Samuel Williams.
+# Copyright, 2023, by Thomas Morgan.
 
 require_relative 'http1'
 
@@ -20,13 +21,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http11.rb
+++ b/lib/async/http/protocol/http11.rb
@@ -3,6 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2017-2024, by Samuel Williams.
 # Copyright, 2018, by Janko Marohnić.
+# Copyright, 2023, by Thomas Morgan.
 
 require_relative 'http1'
 
@@ -21,13 +22,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http2.rb
+++ b/lib/async/http/protocol/http2.rb
@@ -2,11 +2,12 @@
 
 # Released under the MIT License.
 # Copyright, 2018-2024, by Samuel Williams.
+# Copyright, 2023, by Thomas Morgan.
 
 require_relative 'http2/client'
 require_relative 'http2/server'
 
-require 'io/stream/buffered'
+require 'io/stream'
 
 module Async
 	module HTTP
@@ -37,7 +38,7 @@ module Async
 				}
 				
 				def self.client(peer, settings = CLIENT_SETTINGS)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					client = Client.new(stream)
 					
 					client.send_connection_preface(settings)
@@ -47,7 +48,7 @@ module Async
 				end
 				
 				def self.server(peer, settings = SERVER_SETTINGS)
-					stream = ::IO::Stream::Buffered.wrap(peer)
+					stream = ::IO::Stream(peer)
 					server = Server.new(stream)
 					
 					server.read_connection_preface(settings)

--- a/test/async/http/endpoint.rb
+++ b/test/async/http/endpoint.rb
@@ -155,7 +155,7 @@ end
 
 describe Async::HTTP::Endpoint.parse("http://www.google.com/search") do
 	it "should select the correct protocol" do
-		expect(subject.protocol).to be == Async::HTTP::Protocol::HTTP1
+		expect(subject.protocol).to be == Async::HTTP::Protocol::HTTP
 	end
 	
 	it "should parse the correct hostname" do

--- a/test/async/http/protocol/http.rb
+++ b/test/async/http/protocol/http.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Thomas Morgan.
+
+require 'async/http/protocol/http'
+require 'async/http/a_protocol'
+
+describe Async::HTTP::Protocol::HTTP do
+	with 'server' do
+		include Sus::Fixtures::Async::HTTP::ServerContext
+		let(:protocol) {subject}
+		
+		with 'http11 client' do
+			it 'should make a successful request' do
+				response = client.get('/')
+				expect(response).to be(:success?)
+				expect(response.version).to be == 'HTTP/1.1'
+				response.read
+			end
+		end
+		
+		with 'http2 client' do
+			def make_client(endpoint, **options)
+				options[:protocol] = Async::HTTP::Protocol::HTTP2
+				super
+			end
+			
+			it 'should make a successful request' do
+				response = client.get('/')
+				expect(response).to be(:success?)
+				expect(response.version).to be == 'HTTP/2'
+				response.read
+			end
+		end
+	end
+end


### PR DESCRIPTION
This PR adds `Async::HTTP::Protocol::HTTP` which auto-detects HTTP1 vs HTTP2 for inbound (server) connections. It is comparable to `Async::HTTP::Protocol::HTTPS`, just for http:// instead.

It uses HTTP/2 Connection Preface detection, outlined in the [HTTP/2 RFC](https://www.rfc-editor.org/rfc/rfc9113.html#section-3.4).

This is only for server connections. Protocol::HTTP's client always uses HTTP1 as there is no present facility in the RFC for auto-detection for clients using http://. (There was some language around Upgrade: h2c in earlier RFC versions, but it has since been removed.)


<details>
<summary><h4><del>Note on HTTP/1.0</del></h4></summary>

~~HTTP/1.0 requests have the potential to be too short to be properly detected. This is expected behavior, and is treated no differently than any other incomplete inbound HTTP/1.x request.~~

~~The risk is limited to HTTP/1.0 requests without any headers, including no Host header, such as:~~
```
GET / HTTP/1.0

```
~~It's 6 bytes short, and it's only because the Host header is optional in HTTP/1.0. If Host, any other header (ie: User-Agent), a longer path, or a query parameter is present, then it's good to go.~~

~~The only place this might show up is using an ultra-basic monitoring script for health checks. Even most of those will add Host and/or User-Agent, but if not, adding a dummy header or query param will solve it (or using https://).~~

~~Any Server needing assured HTTP/1.0 request support should continue to use Protocol::HTTP1 and not switch to this new Protocol::HTTP.~~
</details>


#### Outstanding considerations

1) Auto-detection uses `peek()` and requires converting the IO Socket into an `Async::IO::Stream` one layer earlier. This PR presently modifies the other Protocol::HTTPxx modules to handle this. It's a rather limited change.

    However, I could see changing `IO::Stream.new(...)` in each of these to a new `IO::Stream.wrap(...)` method and then moving the `is_a?` detection into there.

    Let me know if you'd prefer that and I'll change it here and submit a parallel PR on async-io for that.

2) I'm unsure whether it's appropriate to change the default value in `Async::HTTP::Endpoint#protocol` from `HTTP1` to `HTTP`. I have not included that change at this time, but let me know if you'd like it added.

As always, questions and feedback welcomed.


## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
