### PR TITLE
Make fail_request properly finish the response

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -3,6 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2018-2023, by Samuel Williams.
 # Copyright, 2020, by Igor Sidorov.
+# Copyright, 2023, by Thomas Morgan.
 
 require_relative 'connection'
 
@@ -14,6 +15,9 @@ module Async
 					def fail_request(status)
 						@persistent = false
 						write_response(@version, status, {}, nil)
+						write_body(@version, nil)
+					rescue Errno::ECONNRESET, Errno::EPIPE
+						# Handle when connection is already closed
 					end
 					
 					def next_request

--- a/spec/async/http/protocol/http11_spec.rb
+++ b/spec/async/http/protocol/http11_spec.rb
@@ -3,12 +3,32 @@
 # Released under the MIT License.
 # Copyright, 2017-2023, by Samuel Williams.
 # Copyright, 2018, by Janko Marohnić.
+# Copyright, 2023, by Thomas Morgan.
 
 require 'async/http/protocol/http11'
 require_relative 'shared_examples'
 
 RSpec.describe Async::HTTP::Protocol::HTTP11 do
 	it_behaves_like Async::HTTP::Protocol
+	
+	context 'bad requests' do
+		include_context Async::HTTP::Server
+		
+		around do |example|
+			current = Console.logger.level
+			Console.logger.fatal!
+			
+			example.run
+		ensure
+			Console.logger.level = current
+		end
+
+		it "should fail cleanly when path is empty" do
+			response = client.get("")
+			
+			expect(response.status).to be == 400
+		end
+	end
 	
 	context 'head request' do
 		include_context Async::HTTP::Server


### PR DESCRIPTION
Previously `fail_request` wrote the initial part of the response, but failed to finish it. When tested with `Async::HTTP::Client`, this caused the client to experience an `EOFError`.

This PR causes `fail_request` to now finish the response. It also rescues exceptions that might arise from the attempt to write the response.

Before:
```
HTTP/1.1 400 Bad Request
```

After:
```
HTTP/1.1 400 Bad Request
connection: close
content-length: 0
                  <- required final blank line
```



## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
