### PR TITLE
Fix Delayed when required after async/http/protocol/*

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,3 @@
 Viacheslav Koval <theathlet@yandex.ru>
 Sam Shadwell <git@samshadwell.com>
+Thomas Morgan <tm@iprog.com>

--- a/lib/async/http/body/delayed.rb
+++ b/lib/async/http/body/delayed.rb
@@ -9,7 +9,7 @@ require 'protocol/http/body/wrapper'
 module Async
 	module HTTP
 		module Body
-			class Delayed < Protocol::HTTP::Body::Wrapper
+			class Delayed < ::Protocol::HTTP::Body::Wrapper
 				def initialize(body, delay = 0.01)
 					super(body)
 					


### PR DESCRIPTION
If any part of `async/http/protocol/*` is required before `Async::HTTP::Body::Delayed`, then `Delayed` cannot be loaded. This PR corrects that.

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
