### PR TITLE
Improve handling of unconsumed request bodies at end of http1 requests

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -83,7 +83,7 @@ module Async
 										version = request.version
 										
 										# Same as above:
-										request = nil unless body
+										request = nil unless request.body
 										response = nil
 										
 										write_body(version, body, head, trailer)
@@ -98,7 +98,7 @@ module Async
 								end
 								
 								# Gracefully finish reading the request body if it was not already done so.
-								request&.finish
+								request&.each{}
 								
 								# This ensures we yield at least once every iteration of the loop and allow other fibers to execute.
 								task.yield
@@ -109,6 +109,7 @@ module Async
 							end
 						end
 					end
+					
 				end
 			end
 		end


### PR DESCRIPTION
This PR includes 2 related items:

1. Fixes an old regression where `request = nil` should be conditional upon the _request_ body, but was incorrectly the _response_ body. Looking at the git history, the original behavior was `... unless request.body` and was changed in b3cc9ce, seemingly accidentally during a refactor.

   I occasionally experience random hangs when running my test suite and believe this might be one cause of them.

2. Changes the handling of unconsumed bodies from `request.finish` to `request.each{}`. 

   `finish` buffers the request fully in memory as a `Buffered`, causing needless memory bloat in the ruby process. Using `each` skips the buffering, but is otherwise behaves the same.

## Types of Changes

- Bug fix.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
