### PR TITLE
Downgrade log level

### DIFF
--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -65,7 +65,7 @@ module Async
 							@input = nil
 						end
 					rescue ::Protocol::HTTP2::HeaderError => error
-						Console.logger.error(self, error)
+						Console.logger.debug(self, error)
 						
 						send_reset_stream(error.code)
 					end


### PR DESCRIPTION
This PR changes one log entry from `error` to `debug` to reduce log noise. Since this exception is fully handled by resetting the stream, using `error` seems unnecessary.

## Types of Changes

- Maintenance.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
