### PR TITLE
Save reason phrase in Protocol::HTTP1::Response

### DIFF
--- a/lib/async/http/protocol/http1/response.rb
+++ b/lib/async/http/protocol/http1/response.rb
@@ -18,7 +18,8 @@ module Async
 					
 					UPGRADE = 'upgrade'
 
-					attr_reader :reason
+          # @attribute [String] The HTTP response line reason.
+					attr :reason
 
 					# @param reason [String] HTTP response line reason phrase
 					def initialize(connection, version, status, reason, headers, body)

--- a/lib/async/http/protocol/http1/response.rb
+++ b/lib/async/http/protocol/http1/response.rb
@@ -18,9 +18,12 @@ module Async
 					
 					UPGRADE = 'upgrade'
 
-					# @param reason [String] HTTP response line reason, ignored.
+					attr_reader :reason
+
+					# @param reason [String] HTTP response line reason phrase
 					def initialize(connection, version, status, reason, headers, body)
 						@connection = connection
+						@reason = reason
 						
 						protocol = headers.delete(UPGRADE)
 						
@@ -30,7 +33,7 @@ module Async
 					def connection
 						@connection
 					end
-					
+
 					def hijack?
 						@body.nil?
 					end

--- a/lib/async/http/protocol/http1/response.rb
+++ b/lib/async/http/protocol/http1/response.rb
@@ -21,7 +21,7 @@ module Async
           # @attribute [String] The HTTP response line reason.
 					attr :reason
 
-					# @param reason [String] HTTP response line reason phrase
+					# @parameter reason [String] HTTP response line reason phrase
 					def initialize(connection, version, status, reason, headers, body)
 						@connection = connection
 						@reason = reason

--- a/test/async/http/protocol/http11.rb
+++ b/test/async/http/protocol/http11.rb
@@ -46,6 +46,7 @@ describe Async::HTTP::Protocol::HTTP11 do
 					expect(response).to be(:success?)
 					expect(response.version).to be == "HTTP/1.1"
 					expect(response.body).to be(:empty?)
+					expect(response.reason).to be == "OK"
 					
 					response.read
 				end
@@ -73,6 +74,12 @@ describe Async::HTTP::Protocol::HTTP11 do
 				response = client.get("/")
 				
 				expect(response.read).to be == "Hello World!"
+			end
+
+			it "has access to the http reason phrase" do
+				response = client.head("/")
+
+				expect(response.reason).to be == "It worked!"
 			end
 		end
 	end


### PR DESCRIPTION
Save away the raw reason phrase provided by the server. This is of limited niche value, as the reason phrase seems to be _mostly_ unused/ignored.

One example of where it's needed:

The [Proxmox VE API](https://pve.proxmox.com/wiki/Proxmox_VE_API) ships error reason strings back using the HTTP reason phrase. Without this side-channel, error status is 100% opaque/unavailable.

See (very brief) discussion: https://github.com/socketry/async-http/discussions/145

It's probably not worth overthinking this, but some other thoughts that came to mind were:

* Does it make sense to define a reason accessor in other HTTP version responses so the method is always available?
  * My opinion: no, not worth it and feels pretty bad to burden other versions of HTTP with this detail when it's nearly irrelevant.
* Is it worth any sort of string optimization scheme? (e.g., [String#dedup](https://ruby-doc.org/3.2.2/String.html#method-i-2D-40).)
  * My opinion: probably not, but happy to hear why it's a good idea.


## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
