### PR TITLE
Replace `Async::IO` with native `IO`.

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.1"
 	
-	spec.add_dependency "async", ">= 1.25"
-	spec.add_dependency "async-io", ">= 1.43.1"
+	spec.add_dependency "async", ">= 2.10.2"
 	spec.add_dependency "async-pool", ">= 0.6.1"
-	spec.add_dependency "io-stream", "~> 0.1.1"
+	spec.add_dependency "io-endpoint", "~> 0.10.0"
+	spec.add_dependency "io-stream", "~> 0.3.0"
 	spec.add_dependency "protocol-http", "~> 0.26.0"
 	spec.add_dependency "protocol-http1", "~> 0.19.0"
 	spec.add_dependency "protocol-http2", "~> 0.17.0"

--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.1"
 	
 	spec.add_dependency "async", ">= 1.25"
-	spec.add_dependency "async-io", ">= 1.28"
+	spec.add_dependency "async-io", ">= 1.43.1"
 	spec.add_dependency "async-pool", ">= 0.6.1"
+	spec.add_dependency "io-stream", "~> 0.1.1"
 	spec.add_dependency "protocol-http", "~> 0.26.0"
 	spec.add_dependency "protocol-http1", "~> 0.19.0"
 	spec.add_dependency "protocol-http2", "~> 0.17.0"

--- a/bake/async/http/h2spec.rb
+++ b/bake/async/http/h2spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 def build
 	# Fetch the code:
@@ -24,9 +24,9 @@ def server
 	require 'async'
 	require 'async/container'
 	require 'async/http/server'
-	require 'async/io/host_endpoint'
+	require 'io/endpoint/host_endpoint'
 	
-	endpoint = Async::IO::Endpoint.tcp('127.0.0.1', 7272)
+	endpoint = IO::Endpoint.tcp('127.0.0.1', 7272)
 	
 	container = Async::Container.new
 	

--- a/config/external.yaml
+++ b/config/external.yaml
@@ -9,7 +9,7 @@ async-websocket:
   command: bundle exec sus
 async-http-faraday:
   url: https://github.com/socketry/async-http-faraday.git
-  command: bundle exec rspec
+  command: bundle exec bake test
 # async-http-cache:
 #   url: https://github.com/socketry/async-http-cache.git
 #   command: bundle exec rspec

--- a/examples/google/codeotaku.rb
+++ b/examples/google/codeotaku.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2020-2023, by Samuel Williams.
+# Copyright, 2020-2024, by Samuel Williams.
 
 require "async"
 require "async/clock"
@@ -11,8 +11,6 @@ require_relative "../../lib/async/http"
 
 URL = "https://www.codeotaku.com/index"
 ENDPOINT = Async::HTTP::Endpoint.parse(URL)
-
-Console.logger.enable(Async::IO::Stream, Console::Logger::DEBUG)
 
 if count = ENV['COUNT']&.to_i
 	terms = terms.first(count)

--- a/examples/google/search.rb
+++ b/examples/google/search.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require "async"
 require "async/clock"
@@ -11,8 +11,6 @@ require_relative "../../lib/async/http"
 
 URL = "https://www.google.com/search"
 ENDPOINT = Async::HTTP::Endpoint.parse(URL)
-
-# Console.logger.enable(Async::IO::Stream, Console::Logger::DEBUG)
 
 class Google < Protocol::HTTP::Middleware
 	def search(term)

--- a/fixtures/async/http/a_protocol.rb
+++ b/fixtures/async/http/a_protocol.rb
@@ -202,6 +202,9 @@ module Async
 				end
 				
 				it "disconnects slow clients" do
+					# We won't be able to disconnect slow clients if IO#timeout is not available:
+					skip_unless_method_defined(:timeout, IO)
+					
 					response = client.get("/")
 					response.read
 					
@@ -478,9 +481,11 @@ module Async
 				end
 				
 				it "can't get /" do
+					skip_unless_method_defined(:timeout, IO)
+					
 					expect do
 						client.get("/")
-					end.to raise_exception(Async::TimeoutError)
+					end.to raise_exception(::IO::TimeoutError)
 				end
 			end
 			

--- a/gems.rb
+++ b/gems.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2017-2023, by Samuel Williams.
+# Copyright, 2017-2024, by Samuel Williams.
 
 source 'https://rubygems.org'
 
@@ -9,8 +9,11 @@ gemspec
 
 # gem "async", path: "../async"
 # gem "async-io", path: "../async-io"
+# gem "io-endpoint", path: "../io-endpoint"
 # gem "io-stream", path: "../io-stream"
+# gem "openssl", git: "https://github.com/ruby/openssl.git"
 # gem "traces", path: "../traces"
+# gem "sus-fixtures-async-http", path: "../sus-fixtures-async-http"
 
 # gem "protocol-http", path: "../protocol-http"
 # gem "protocol-http1", path: "../protocol-http1"
@@ -29,7 +32,7 @@ group :test do
 	gem "covered"
 	gem "sus"
 	gem "sus-fixtures-async"
-	gem "sus-fixtures-async-http", "~> 0.7"
+	gem "sus-fixtures-async-http", "~> 0.8"
 	gem "sus-fixtures-openssl"
 	
 	gem "bake"

--- a/gems.rb
+++ b/gems.rb
@@ -9,6 +9,7 @@ gemspec
 
 # gem "async", path: "../async"
 # gem "async-io", path: "../async-io"
+# gem "io-stream", path: "../io-stream"
 # gem "traces", path: "../traces"
 
 # gem "protocol-http", path: "../protocol-http"

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 # Copyright, 2020, by Bruno Sutic.
-
-require 'async/io/socket'
-require 'async/io/stream'
 
 require_relative 'writable'
 
@@ -18,9 +15,9 @@ module Async
 					@input = input
 					@output = output
 					
-					head, tail = IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+					head, tail = ::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
 					
-					@head = IO::Stream.new(head)
+					@head = ::IO::Stream::Buffered.new(head)
 					@tail = tail
 					
 					@reader = nil

--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -4,8 +4,7 @@
 # Copyright, 2017-2024, by Samuel Williams.
 # Copyright, 2022, by Ian Ker-Seymer.
 
-require 'async/io/endpoint'
-require 'async/io/stream'
+require 'io/endpoint'
 
 require 'async/pool/controller'
 
@@ -107,7 +106,6 @@ module Async
 					
 					# This signals that the ensure block below should not try to release the connection, because it's bound into the response which will be returned:
 					connection = nil
-					
 					return response
 				rescue Protocol::RequestFailed
 					# This is a specific case where the entire request wasn't sent before a failure occurred. So, we can even resend non-idempotent requests.
@@ -133,7 +131,9 @@ module Async
 						raise
 					end
 				ensure
-					@pool.release(connection) if connection
+					if connection
+						@pool.release(connection)
+					end
 				end
 			end
 			

--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -4,10 +4,9 @@
 # Copyright, 2019-2024, by Samuel Williams.
 # Copyright, 2021-2022, by Adam Daniels.
 
-require 'async/io/host_endpoint'
-require 'async/io/ssl_endpoint'
-require 'async/io/ssl_socket'
-require 'async/io/shared_endpoint'
+require 'io/endpoint'
+require 'io/endpoint/host_endpoint'
+require 'io/endpoint/ssl_endpoint'
 
 require_relative 'protocol/http1'
 require_relative 'protocol/https'
@@ -15,7 +14,7 @@ require_relative 'protocol/https'
 module Async
 	module HTTP
 		# Represents a way to connect to a remote HTTP server.
-		class Endpoint < Async::IO::Endpoint
+		class Endpoint < ::IO::Endpoint::Generic
 			def self.parse(string, endpoint = nil, **options)
 				url = URI.parse(string).normalize
 				
@@ -164,7 +163,7 @@ module Async
 				
 				if secure?
 					# Wrap it in SSL:
-					return Async::IO::SSLEndpoint.new(endpoint,
+					return ::IO::Endpoint::SSLEndpoint.new(endpoint,
 						ssl_context: self.ssl_context,
 						hostname: @url.hostname,
 						timeout: self.timeout,
@@ -226,7 +225,7 @@ module Async
 			end
 			
 			def tcp_endpoint
-				Async::IO::Endpoint.tcp(self.hostname, port, **tcp_options)
+				::IO::Endpoint.tcp(self.hostname, port, **tcp_options)
 			end
 		end
 	end

--- a/lib/async/http/protocol/http1.rb
+++ b/lib/async/http/protocol/http1.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2017-2023, by Samuel Williams.
+# Copyright, 2017-2024, by Samuel Williams.
 
 require_relative 'http1/client'
 require_relative 'http1/server'
+
+require 'io/stream/buffered'
 
 module Async
 	module HTTP
@@ -21,13 +23,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -62,7 +62,7 @@ module Async
 					
 					# Can we use this connection to make requests?
 					def viable?
-						@ready && @stream&.connected?
+						@ready && @stream&.readable?
 					end
 					
 					def reusable?

--- a/lib/async/http/protocol/http1/request.rb
+++ b/lib/async/http/protocol/http1/request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2018-2024, by Samuel Williams.
 
 require_relative '../request'
 
@@ -15,7 +15,7 @@ module Async
 							self.new(connection, *parts)
 						end
 					end
-
+					
 					UPGRADE = 'upgrade'
 					
 					def initialize(connection, authority, method, path, version, headers, body)

--- a/lib/async/http/protocol/http10.rb
+++ b/lib/async/http/protocol/http10.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2017-2023, by Samuel Williams.
+# Copyright, 2017-2024, by Samuel Williams.
 
 require_relative 'http1'
 
@@ -20,13 +20,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http11.rb
+++ b/lib/async/http/protocol/http11.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2017-2023, by Samuel Williams.
+# Copyright, 2017-2024, by Samuel Williams.
 # Copyright, 2018, by Janko Marohnić.
 
 require_relative 'http1'
@@ -21,13 +21,13 @@ module Async
 				end
 				
 				def self.client(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Client.new(stream, VERSION)
 				end
 				
 				def self.server(peer)
-					stream = IO::Stream.new(peer, sync: true)
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					
 					return HTTP1::Server.new(stream, VERSION)
 				end

--- a/lib/async/http/protocol/http2.rb
+++ b/lib/async/http/protocol/http2.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2018-2024, by Samuel Williams.
 
 require_relative 'http2/client'
 require_relative 'http2/server'
+
+require 'io/stream/buffered'
 
 module Async
 	module HTTP
@@ -35,8 +37,7 @@ module Async
 				}
 				
 				def self.client(peer, settings = CLIENT_SETTINGS)
-					stream = IO::Stream.new(peer, sync: true)
-					
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					client = Client.new(stream)
 					
 					client.send_connection_preface(settings)
@@ -46,8 +47,7 @@ module Async
 				end
 				
 				def self.server(peer, settings = SERVER_SETTINGS)
-					stream = IO::Stream.new(peer, sync: true)
-					
+					stream = ::IO::Stream::Buffered.wrap(peer)
 					server = Server.new(stream)
 					
 					server.read_connection_preface(settings)

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -122,7 +122,7 @@ module Async
 					
 					# Can we use this connection to make requests?
 					def viable?
-						@stream.connected?
+						@stream&.readable?
 					end
 					
 					def reusable?

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -90,19 +90,18 @@ module Async
 									self.consume_window
 									self.read_frame
 								end
-							rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Async::Wrapper::Cancelled
-								# Ignore.
-							rescue ::Protocol::HTTP2::GoawayError => error
+							rescue Async::Stop, ::IO::TimeoutError, ::Protocol::HTTP2::GoawayError => error
 								# Error is raised if a response is actively reading from the
 								# connection. The connection is silently closed if GOAWAY is
 								# received outside the request/response cycle.
-								if @reader
-									self.close(error)
-								end
+							rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE => ignored_error
+								# Ignore.
+							rescue => error
+								# Every other error.
 							ensure
 								# Don't call #close twice.
 								if @reader
-									self.close($!)
+									self.close(error)
 								end
 							end
 						end

--- a/lib/async/http/proxy.rb
+++ b/lib/async/http/proxy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require_relative 'client'
 require_relative 'endpoint'
@@ -46,7 +46,7 @@ module Async
 			# @param host [String] the hostname or address to connect to.
 			# @param port [String] the port number to connect to.
 			# @param headers [Array] an optional list of headers to use when establishing the connection.
-			# @see Async::IO::Endpoint#tcp
+			# @see IO::Endpoint#tcp
 			def self.tcp(client, host, port, headers = nil)
 				self.new(client, "#{host}:#{port}", headers)
 			end

--- a/lib/async/http/server.rb
+++ b/lib/async/http/server.rb
@@ -4,8 +4,7 @@
 # Copyright, 2017-2024, by Samuel Williams.
 # Copyright, 2019, by Brian Morearty.
 
-require 'async/io/endpoint'
-require 'async/io/stream'
+require 'io/endpoint'
 
 require 'protocol/http/middleware'
 

--- a/test/async/http/body.rb
+++ b/test/async/http/body.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2018-2024, by Samuel Williams.
 
 require 'async/http/body'
 
@@ -9,6 +9,7 @@ require 'sus/fixtures/async'
 require 'sus/fixtures/openssl'
 require 'sus/fixtures/async/http'
 require 'localhost/authority'
+require 'io/endpoint/ssl_endpoint'
 
 ABody = Sus::Shared("a body") do
 	with 'echo server' do
@@ -97,11 +98,11 @@ describe Async::HTTP::Protocol::HTTPS do
 	let(:client_context) {authority.client_context}
 	
 	def make_server_endpoint(bound_endpoint)
-		Async::IO::SSLEndpoint.new(super, ssl_context: server_context)
+		::IO::Endpoint::SSLEndpoint.new(super, ssl_context: server_context)
 	end
 	
 	def make_client_endpoint(bound_endpoint)
-		Async::IO::SSLEndpoint.new(super, ssl_context: client_context)
+		::IO::Endpoint::SSLEndpoint.new(super, ssl_context: client_context)
 	end
 	
 	it_behaves_like ABody

--- a/test/async/http/body/pipe.rb
+++ b/test/async/http/body/pipe.rb
@@ -42,7 +42,7 @@ describe Async::HTTP::Body::Pipe do
 		end
 		
 		it "returns an io socket" do
-			expect(io).to be_a(Async::IO::Socket)
+			expect(io).to be_a(::Socket)
 			expect(io.read).to be == data
 		end
 		

--- a/test/async/http/endpoint.rb
+++ b/test/async/http/endpoint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2018-2024, by Samuel Williams.
 # Copyright, 2021-2022, by Adam Daniels.
 
 require 'async/http/endpoint'
@@ -36,7 +36,7 @@ describe Async::HTTP::Endpoint do
 			end
 			
 			it "should be connecting to 127.0.0.1" do
-				expect(subject.endpoint).to be_a Async::IO::SSLEndpoint
+				expect(subject.endpoint).to be_a ::IO::Endpoint::SSLEndpoint
 				expect(subject.endpoint).to have_attributes(hostname: be == '127.0.0.1')
 				expect(subject.endpoint.endpoint).to have_attributes(hostname: be == '127.0.0.1')
 			end
@@ -49,7 +49,7 @@ describe Async::HTTP::Endpoint do
 			end
 			
 			it "should be connecting to localhost" do
-				expect(subject.endpoint).to be_a Async::IO::SSLEndpoint
+				expect(subject.endpoint).to be_a ::IO::Endpoint::SSLEndpoint
 				expect(subject.endpoint).to have_attributes(hostname: be == '127.0.0.1')
 				expect(subject.endpoint.endpoint).to have_attributes(hostname: be == 'localhost')
 			end

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -124,7 +124,7 @@ AProxy = Sus::Shared("a proxy") do
 				end
 				
 				host, port = request.path.split(":", 2)
-				endpoint = Async::IO::Endpoint.tcp(host, port)
+				endpoint = IO::Endpoint.tcp(host, port)
 				
 				Console.logger.debug(self) {"Making connection to #{endpoint}..."}
 				

--- a/test/async/http/ssl.rb
+++ b/test/async/http/ssl.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2018-2024, by Samuel Williams.
 
 require 'async/http/server'
 require 'async/http/client'
 require 'async/http/endpoint'
-
-require 'async/io/ssl_socket'
 
 require 'sus/fixtures/async'
 require 'sus/fixtures/openssl'
@@ -41,11 +39,11 @@ describe Async::HTTP::Server do
 		end
 		
 		def make_server_endpoint(bound_endpoint)
-			Async::IO::SSLEndpoint.new(super, ssl_context: server_context)
+			::IO::Endpoint::SSLEndpoint.new(super, ssl_context: server_context)
 		end
 		
 		def make_client_endpoint(bound_endpoint)
-			Async::IO::SSLEndpoint.new(super, ssl_context: client_context)
+			::IO::Endpoint::SSLEndpoint.new(super, ssl_context: client_context)
 		end
 		
 		it "client can get a resource via https" do


### PR DESCRIPTION
Remove the `async-io` dependency.

- `Async::IO::Endpoint` is replaced by `IO::Endpoint`: https://github.com/socketry/io-endpoint
- Ruby 3.1 won't be fully supported due to lack of `IO#timeout` support.
- We require a large number of bug fixes in <https://github.com/ruby/openssl/issues/741>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
