### PR TITLE
Require shared endpoint by default.

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -7,6 +7,7 @@
 require 'async/io/host_endpoint'
 require 'async/io/ssl_endpoint'
 require 'async/io/ssl_socket'
+require 'async/io/shared_endpoint'
 
 require_relative 'protocol/http1'
 require_relative 'protocol/https'


### PR DESCRIPTION
Require shared endpoint by default to reduce pain in migrating to `io-endpoint`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
