### PR TITLE
Avoid writing to the body after full hijack

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-io", ">= 1.28"
 	spec.add_dependency "async-pool", ">= 0.2"
 	spec.add_dependency "protocol-http", "~> 0.26.0"
-	spec.add_dependency "protocol-http1", "~> 0.18.0"
+	spec.add_dependency "protocol-http1", "~> 0.19.0"
 	spec.add_dependency "protocol-http2", "~> 0.16.0"
 	spec.add_dependency "traces", ">= 0.10.0"
 end

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -18,6 +18,7 @@ module Async
 						
 						@ready = true
 						@version = version
+						@hijacked = false
 					end
 					
 					attr :version
@@ -46,6 +47,15 @@ module Async
 					
 					def concurrency
 						1
+					end
+
+					def hijack!
+						@hijacked = true
+						super
+					end
+
+					def hijacked?
+						@hijacked
 					end
 					
 					# Can we use this connection to make requests?

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -18,7 +18,6 @@ module Async
 						
 						@ready = true
 						@version = version
-						@hijacked = false
 					end
 					
 					attr :version
@@ -47,15 +46,6 @@ module Async
 					
 					def concurrency
 						1
-					end
-
-					def hijack!
-						@hijacked = true
-						super
-					end
-
-					def hijacked?
-						@hijacked
 					end
 					
 					# Can we use this connection to make requests?

--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -50,10 +50,7 @@ module Async
 							response = yield(request, self)
 							body = response&.body
 							
-							if @stream.nil? and body.nil?
-								# Full hijack.
-								return
-							end
+							return if hijacked?
 							
 							task.defer_stop do
 								# If a response was generated, send it:

--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -50,7 +50,10 @@ module Async
 							response = yield(request, self)
 							body = response&.body
 							
-							return if hijacked?
+							if hijacked?
+								body&.close
+								return
+							end
 							
 							task.defer_stop do
 								# If a response was generated, send it:

--- a/test/async/http/protocol/http11.rb
+++ b/test/async/http/protocol/http11.rb
@@ -103,7 +103,7 @@ describe Async::HTTP::Protocol::HTTP11 do
 			end
 
 			it "works properly" do
-				expect(body).not.to receive(:close)
+				expect(body).to receive(:close)
 
 				response = client.get("/")
 


### PR DESCRIPTION
Whenever the application performs hijacking of http/1.1 connection, the server must not attempt to send any response back to the client. Prior to this change, it was not the case due to imprecise check and has led to an error being logged (the real issue occurred during an attempt to write to a stream that was set to nil, but that's really just a symptom).

The proposed fix simply adds a flag to the connection object so that it is aware of the fact the underlying stream no longer belongs to it and must not be used to send any data over.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
