### PR TITLE
allow defining clients on initialization

### DIFF
--- a/lib/async/http/internet.rb
+++ b/lib/async/http/internet.rb
@@ -14,7 +14,7 @@ module Async
 	module HTTP
 		class Internet
 			def initialize(**options)
-				@clients = Hash.new
+				@clients = options.delete(:clients) || Hash.new
 				@options = options
 			end
 			

--- a/readme.md
+++ b/readme.md
@@ -270,19 +270,19 @@ api_endpoint = Async::HTTP::Endpoint.parse(api_url, ssl_context: ssl_context)
 auth_endpoint = Async::HTTP::Endpoint.parse(auth_url, ssl_context: ssl_context)
 
 clients = {
-	api_url => Async::HTTP::Client.new(api_endpoint),
+  api_url => Async::HTTP::Client.new(api_endpoint),
   auth_url => Async::HTTP::Client.new(auth_endpoint)
 }
 
 
 Async do
-	internet = Async::HTTP::Internet.new(clients: clients)
-	token_response = internet.get("#{internet}/auth/token")
-	token = JSON.parse(token_response.read).dig("token")
-	headers = [['Authorization', "Bearer #{token}"]]
-	widgets_response = internet.get("#{api_url}/widgets", headers )
+  internet = Async::HTTP::Internet.new(clients: clients)
+  token_response = internet.get("#{internet}/auth/token")
+  token = JSON.parse(token_response.read).dig("token")
+  headers = [['Authorization', "Bearer #{token}"]]
+  widgets_response = internet.get("#{api_url}/widgets", headers )
 	
-	pp widgets_response.status, widgets_response.headers.fields, widgets_response.read
+  pp widgets_response.status, widgets_response.headers.fields, widgets_response.read
 end
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -260,9 +260,9 @@ ssl_private_key = OpenSSL::PKey::RSA.new(ENV['PRIVATE_SSL_KEY_AS_STRING']))
 ssl_certificate = OpenSSL::X509::Certificate.new(OpenSSL::X509::Certificate.new(ENV['PUBLIC_SSL_CERTIFICATE_AS_STRING'])
 
 ssl_context =  OpenSSL::SSL::SSLContext.new.tap do |context|
-      context.cert = ssl_certificate
-      context.key = ssl_private_key
-    end
+  context.cert = ssl_certificate
+  context.key = ssl_private_key
+end
 api_url = 'https://www.example-api.com'
 auth_url = 'https://www.example-auth.com'
 

--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ Async do
 end
 ```
 
-### Private Certificate Authentication Verification
+### Private Certificate Authentication
 
 You provide private certificates for authentication.
 


### PR DESCRIPTION
We needed to use vendor provideded SSL certificates to make calls to multiple domains from `Async::HTTP::Internet`.  Unfortunately, the `options` that you can pass in are only for a single URL.  To allow for our use case, we need to define `url => Async::HTTP::Client` outside of our `Async::HTTP::Internet.new` call and pass them in as an argument.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->
- New feature.
- Updated documentation.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
