### PR TITLE
Defer stop

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -55,7 +55,7 @@ module Async
 								return
 							end
 							
-							begin
+							task.defer_stop do
 								# If a response was generated, send it:
 								if response
 									trailer = response.headers.trailer!

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -89,7 +89,7 @@ module Async
 							
 							task.annotate("#{version} reading data for #{self.class}.")
 							
-							begin
+							task.defer_stop do
 								while !self.closed?
 									self.consume_window
 									self.read_frame

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -89,7 +89,8 @@ module Async
 							
 							task.annotate("#{version} reading data for #{self.class}.")
 							
-							task.defer_stop do
+							# We don't need to defer stop here as this is already a transient task (ignores stop):
+							begin
 								while !self.closed?
 									self.consume_window
 									self.read_frame

--- a/lib/async/http/protocol/http2/server.rb
+++ b/lib/async/http/protocol/http2/server.rb
@@ -53,7 +53,7 @@ module Async
 							
 							@count += 1
 							
-							begin
+							task.defer_stop do
 								response = yield(request)
 							rescue
 								# We need to close the stream if the user code blows up while generating a response:


### PR DESCRIPTION
Add support for `defer_stop` for graceful shutdown. These changes are necessary but I'm not sure if they are sufficient - more experimentation is required to see the exact impact to client behaviour.

See <https://github.com/socketry/falcon/issues/71> for more details.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
