### PR TITLE
Let's be more specific w.r.t. `Async::HTTP::Server#run`.

### DIFF
--- a/lib/async/http/server.rb
+++ b/lib/async/http/server.rb
@@ -64,9 +64,15 @@ module Async
 			ensure
 				connection&.close
 			end
-			 
+			
+			# @returns [Array(Async::Task)] The task that is running the server.
 			def run
-				@endpoint.accept(&self.method(:accept))
+				Async do
+					@endpoint.accept(&self.method(:accept))
+					
+					# Wait for all children to finish:
+					self.children.each(&:wait)
+				end
 			end
 			
 			Traces::Provider(self) do

--- a/test/async/http/server.rb
+++ b/test/async/http/server.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2017-2024, by Samuel Williams.
+
+require 'async/http/server'
+require 'async/http/endpoint'
+require 'sus/fixtures/async'
+
+describe Async::HTTP::Server do
+	include Sus::Fixtures::Async::ReactorContext
+	
+	let(:endpoint) {Async::HTTP::Endpoint.parse('http://localhost:0')}
+	let(:app) {Protocol::HTTP::Middleware::Okay}
+	let(:server) {subject.new(app, endpoint)}
+	
+	with '#run' do
+		it "runs the server" do
+			task = server.run
+			
+			expect(task).to be_a(Async::Task)
+			
+			task.stop
+		end
+	end
+end


### PR DESCRIPTION
`::IO::Endpoint` returns bare fibers, and we need to wait on them. Change `Async::Server#run` to return a single task which can be waited on.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
