### PR TITLE
Response protocol should only be a single value.

### DIFF
--- a/lib/async/http/protocol/http1/response.rb
+++ b/lib/async/http/protocol/http1/response.rb
@@ -31,7 +31,8 @@ module Async
 						@connection = connection
 						@reason = reason
 						
-						protocol = headers.delete(UPGRADE)
+						# Technically, there should never be more than one value for the upgrade header, but we'll just take the first one to avoid complexity.
+						protocol = headers.delete(UPGRADE)&.first
 						
 						super(version, status, headers, body, protocol)
 					end


### PR DESCRIPTION
HTTP/1 response upgrade header should only have a single value.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
