### PR TITLE
Expose cached peer address interface.

### DIFF
--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -5,6 +5,7 @@
 
 require "protocol/http1"
 
+require_relative "../peer"
 require_relative "request"
 require_relative "response"
 
@@ -42,7 +43,7 @@ module Async
 					end
 					
 					def peer
-						@stream.io
+						@peer ||= Peer.for(@stream.io)
 					end
 					
 					attr :count

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -5,6 +5,7 @@
 # Copyright, 2020, by Bruno Sutic.
 
 require_relative "stream"
+require_relative "../peer"
 
 require "async/semaphore"
 
@@ -112,7 +113,7 @@ module Async
 					attr :promises
 					
 					def peer
-						@stream.io
+						@peer ||= Peer.for(@stream.io)
 					end
 					
 					attr :count

--- a/lib/async/http/protocol/peer.rb
+++ b/lib/async/http/protocol/peer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2017-2024, by Samuel Williams.
+
+module Async
+	module HTTP
+		module Protocol
+			# Provide a well defined, cached representation of a peer (address).
+			class Peer
+				def self.for(io)
+					if address = io.remote_address
+						return new(address)
+					end
+				end
+				
+				def initialize(address)
+					@address = address
+					
+					if address.ip?
+						@ip_address = @address.ip_address
+					end
+				end
+				
+				attr :address
+				attr :ip_address
+				
+				alias remote_address address
+			end
+		end
+	end
+end

--- a/lib/async/http/protocol/request.rb
+++ b/lib/async/http/protocol/request.rb
@@ -29,17 +29,11 @@ module Async
 				end
 				
 				def peer
-					if connection = self.connection
-						connection.peer
-					end
+					self.connection&.peer
 				end
 				
 				def remote_address
-					@remote_address ||= peer.remote_address
-				end
-				
-				def remote_address= value
-					@remote_address = value
+					self.peer&.address
 				end
 				
 				def inspect

--- a/lib/async/http/protocol/response.rb
+++ b/lib/async/http/protocol/response.rb
@@ -21,17 +21,11 @@ module Async
 				end
 				
 				def peer
-					if connection = self.connection
-						connection.peer
-					end
+					self.connection&.peer
 				end
 				
 				def remote_address
-					@remote_address ||= peer.remote_address
-				end
-				
-				def remote_address= value
-					@remote_address = value
+					self.peer&.remote_address
 				end
 				
 				def inspect

--- a/lib/async/http/server.rb
+++ b/lib/async/http/server.rb
@@ -52,9 +52,6 @@ module Async
 					# https://tools.ietf.org/html/rfc7230#section-5.5
 					request.scheme ||= self.scheme
 					
-					# This is a slight optimization to avoid having to get the address from the socket.
-					request.remote_address = address
-					
 					# Console.logger.debug(self) {"Incoming request from #{address.inspect}: #{request.method} #{request.path}"}
 					
 					# If this returns nil, we assume that the connection has been hijacked.


### PR DESCRIPTION
It turns out that `Addrinfo#ip_address` is slow. Let's cache it, since most connections will handle more than one request.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
