### PR TITLE
Remove support for HTTP/2 priority.

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "io-stream", "~> 0.6"
 	spec.add_dependency "protocol-http", "~> 0.43"
 	spec.add_dependency "protocol-http1", ">= 0.28.1"
-	spec.add_dependency "protocol-http2", "~> 0.19"
+	spec.add_dependency "protocol-http2", "~> 0.21"
 	spec.add_dependency "traces", "~> 0.10"
 	spec.add_dependency "metrics", "~> 0.12"
 end

--- a/lib/async/http/protocol/http2/output.rb
+++ b/lib/async/http/protocol/http2/output.rb
@@ -37,6 +37,8 @@ module Async
 						@guard.synchronize do
 							@window_updated.signal
 						end
+						
+						return true
 					end
 					
 					def write(chunk)

--- a/lib/async/http/protocol/http2/request.rb
+++ b/lib/async/http/protocol/http2/request.rb
@@ -112,7 +112,7 @@ module Async
 					
 					def send_response(response)
 						if response.nil?
-							return @stream.send_headers(nil, NO_RESPONSE, ::Protocol::HTTP2::END_STREAM)
+							return @stream.send_headers(NO_RESPONSE, ::Protocol::HTTP2::END_STREAM)
 						end
 						
 						protocol_headers = [
@@ -129,14 +129,14 @@ module Async
 							# This function informs the headers object that any subsequent headers are going to be trailer. Therefore, it must be called *before* sending the headers, to avoid any race conditions.
 							trailer = response.headers.trailer!
 							
-							@stream.send_headers(nil, headers)
+							@stream.send_headers(headers)
 							
 							@stream.send_body(body, trailer)
 						else
 							# Ensure the response body is closed if we are ending the stream:
 							response.close
 							
-							@stream.send_headers(nil, headers, ::Protocol::HTTP2::END_STREAM)
+							@stream.send_headers(headers, ::Protocol::HTTP2::END_STREAM)
 						end
 					end
 					
@@ -149,7 +149,7 @@ module Async
 							interim_response_headers = ::Protocol::HTTP::Headers::Merged.new(interim_response_headers, headers)
 						end
 						
-						@stream.send_headers(nil, interim_response_headers)
+						@stream.send_headers(interim_response_headers)
 					end
 				end
 			end

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -222,7 +222,7 @@ module Async
 						)
 						
 						if request.body.nil?
-							@stream.send_headers(nil, headers, ::Protocol::HTTP2::END_STREAM)
+							@stream.send_headers(headers, ::Protocol::HTTP2::END_STREAM)
 						else
 							if length = request.body.length
 								# This puts it at the end of the pseudo-headers:
@@ -233,7 +233,7 @@ module Async
 							trailer = request.headers.trailer!
 							
 							begin
-								@stream.send_headers(nil, headers)
+								@stream.send_headers(headers)
 							rescue
 								raise RequestFailed
 							end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -131,7 +131,7 @@ module Async
 						else
 							# Write trailer?
 							if trailer&.any?
-								send_headers(nil, trailer, ::Protocol::HTTP2::END_STREAM)
+								send_headers(trailer, ::Protocol::HTTP2::END_STREAM)
 							else
 								send_data(nil, ::Protocol::HTTP2::END_STREAM)
 							end
@@ -142,6 +142,8 @@ module Async
 						super
 						
 						@output&.window_updated(size)
+						
+						return true
 					end
 					
 					# When the stream transitions to the closed state, this method is called. There are roughly two ways this can happen:


### PR DESCRIPTION
Remove the unused support for HTTP/2 priority. This mainly affects `send_headers`, but there were no actual usage of setting the priority, so the impact is effectively zero.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
