### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -52,7 +52,7 @@ module Async
 						end
 						
 						return request
-					rescue ::Protocol::HTTP1::BadRequest => error
+					rescue ::Protocol::HTTP1::BadRequest
 						fail_request(400)
 						# Conceivably we could retry here, but we don't really know how bad the error is, so it's better to just fail:
 						raise

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -94,7 +94,7 @@ module Async
 								# Error is raised if a response is actively reading from the
 								# connection. The connection is silently closed if GOAWAY is
 								# received outside the request/response cycle.
-							rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE => ignored_error
+							rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE
 								# Ignore.
 							rescue => error
 								# Every other error.


### PR DESCRIPTION
```
async-http-0.86.0/lib/async/http/protocol/http1/server.rb:55: warning: assigned but unused variable - error
async-http-0.86.0/lib/async/http/protocol/http2/connection.rb:99: warning: assigned but unused variable - ignored_error
```
