### PR TITLE
Remove compatibility require.

### DIFF
--- a/lib/async/http/endpoint.rb
+++ b/lib/async/http/endpoint.rb
@@ -16,9 +16,6 @@ require_relative "protocol/https"
 
 require "uri"
 
-# Compatibility with Ruby 3.1.2
-require "uri/wss"
-
 module Async
 	module HTTP
 		# Represents a way to connect to a remote HTTP server.


### PR DESCRIPTION
It was necessary to require `uri/wss` in Ruby v3.1.0 to 3.1.3 but those versions are no longer supported by this gem.

### Types of Changes

- Maintenance.

### Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).