### PR TITLE
Fix uninitialized constant in test.

### DIFF
--- a/test/async/http/client/google.rb
+++ b/test/async/http/client/google.rb
@@ -5,6 +5,7 @@
 
 require "async/http/client"
 require "async/http/endpoint"
+require "async/http/body"
 
 require "protocol/http/accept_encoding"
 


### PR DESCRIPTION
Running `sus test/async/http/client/google.rb` results in 1 test error:

```ruby
describe Async::HTTP::Client it can request remote resource with compression test/async/http/client/google.rb:35
	expect #<Async::HTTP::Protocol::HTTP2::Response:0xa50 status=200> to
		be success?
			✓ assertion passed test/async/http/client/google.rb:40
	⚠ NameError: uninitialized constant Async::HTTP::Body::Inflate
		test/async/http/client/google.rb:42 block (3 levels) in <top (required)>
```

The other test files are OK.

### Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).