### PR TITLE
Migrate deprecated `Async::Variable` to `Async::Promise`

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "async", ">= 2.10.2"
+	spec.add_dependency "async", ">= 2.35.1"
 	spec.add_dependency "async-pool", "~> 0.11"
 	spec.add_dependency "io-endpoint", "~> 0.14"
 	spec.add_dependency "io-stream", "~> 0.6"

--- a/fixtures/async/http/a_protocol.rb
+++ b/fixtures/async/http/a_protocol.rb
@@ -5,7 +5,7 @@
 # Copyright, 2020, by Igor Sidorov.
 
 require "async"
-require "async/variable"
+require "async/promise"
 require "async/clock"
 require "async/http/client"
 require "async/http/server"
@@ -131,14 +131,14 @@ module Async
 			end
 			
 			with "with request trailer" do
-				let(:request_received) {Async::Variable.new}
+				let(:request_received) {Async::Promise.new}
 				
 				let(:app) do
 					::Protocol::HTTP::Middleware.for do |request|
 						if trailer = request.headers["trailer"]
 							expect(request.headers).not.to have_keys("etag")
 							
-							request_received.value = true
+							request_received.resolve(true)
 							request.finish
 							
 							expect(request.headers).to have_keys("etag")
@@ -173,7 +173,7 @@ module Async
 			end
 			
 			with "with response trailer" do
-				let(:response_received) {Async::Variable.new}
+				let(:response_received) {Async::Promise.new}
 				
 				let(:app) do
 					::Protocol::HTTP::Middleware.for do |request|
@@ -203,7 +203,7 @@ module Async
 					headers = response.headers
 					expect(headers).not.to have_keys("etag")
 					
-					response_received.value = true
+					response_received.resolve(true)
 					
 					expect(response.read).to be == "response trailer"
 					expect(response).to be(:success?)
@@ -441,7 +441,7 @@ module Async
 					::Protocol::HTTP::Middleware.for do |request|
 						body = Async::HTTP::Body::Writable.new
 						
-						Async::Reactor.run do |task|
+						Async do |task|
 							10.times do |i|
 								chunk = "Chunk #{i}"
 								chunks << chunk
@@ -556,7 +556,7 @@ module Async
 						else
 							count += 1
 							body.write chunk*2
-							Async::Task.current.sleep(0.1)
+							sleep(0.1)
 						end
 					end
 					

--- a/lib/async/http/protocol/http1/finishable.rb
+++ b/lib/async/http/protocol/http1/finishable.rb
@@ -4,7 +4,7 @@
 # Copyright, 2024, by Samuel Williams.
 
 require "protocol/http/body/wrapper"
-require "async/variable"
+require "async/promise"
 
 module Async
 	module HTTP
@@ -17,7 +17,7 @@ module Async
 					def initialize(body)
 						super(body)
 						
-						@closed = Async::Variable.new
+						@closed = Async::Promise.new
 						@error = nil
 						
 						@reading = false
@@ -42,7 +42,7 @@ module Async
 						
 						unless @closed.resolved?
 							@error = error
-							@closed.value = true
+							@closed.resolve(true)
 						end
 					end
 					

--- a/test/async/http/protocol/http2/request_failed_on_refused_stream.rb
+++ b/test/async/http/protocol/http2/request_failed_on_refused_stream.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "async/http/protocol/http2"
+require "async/promise"
 require "sus/fixtures/async/http"
 
 describe Async::HTTP::Protocol::HTTP2 do
@@ -11,7 +12,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}
 		
-		let(:request_count) {Async::Variable.new}
+		let(:request_count) {Async::Promise.new}
 		
 		let(:app) do
 			request_count = self.request_count
@@ -19,7 +20,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 			
 			Protocol::HTTP::Middleware.for do |request|
 				count += 1
-				request_count.value = count
+				request_count.resolve(count)
 				
 				Protocol::HTTP::Response[200, {}, ["OK"]]
 			end

--- a/test/async/http/protocol/http2/response_close_on_stream_error.rb
+++ b/test/async/http/protocol/http2/response_close_on_stream_error.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "async/http/protocol/http2"
+require "async/promise"
 require "sus/fixtures/async/http"
 require "protocol/http/body/wrapper"
 
@@ -12,7 +13,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}
 		
-		let(:body_closed) {Async::Variable.new}
+		let(:body_closed) {Async::Promise.new}
 		
 		let(:app) do
 			body_closed = self.body_closed
@@ -23,7 +24,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 				tracking_body = Class.new(Protocol::HTTP::Body::Wrapper) do
 					define_method(:close) do |error = nil|
 						super(error)
-						body_closed.value = true
+						body_closed.resolve(true)
 					end
 				end.new(inner_body)
 				


### PR DESCRIPTION
## Summary

`Async::Variable` is deprecated in favour of `Async::Promise`, producing:

> `Async::Variable` is deprecated, use `Async::Promise` instead.

Simply renaming the class is not enough. `Async::Promise` does not provide the `value=` writer that `Async::Variable` aliased to `resolve`, so the completion signal `@closed.value = true` in `Finishable#close` has to become `@closed.resolve(true)` — otherwise closing an HTTP/1 body that has been read raises `NoMethodError`, breaking normal request handling. Thanks to the Codex review for catching this.

## Changes

- **`http1/finishable.rb`**: use `Async::Promise` and `resolve(true)` to signal completion.
- **Dependency**: raise `async` to `>= 2.35.1`.
  - `Async::Promise` was introduced in async **2.29.0**, so the previous floor (`>= 2.10.2`) could not load it.
  - **2.35.1** additionally fixes a spurious-wakeup bug in `Async::Promise#wait` — the exact indefinite wait path `Finishable#wait` relies on to block until the body is fully consumed before a persistent connection is reused. (Happy to relax this to `>= 2.29.0` if you'd prefer a lower floor.)
- **Test fixtures**: migrate the remaining `Async::Variable` usages (`a_protocol.rb` and two HTTP/2 tests).
- **Adjacent cleanup**: while editing `a_protocol.rb`, replace two other deprecated calls — `Async::Reactor.run{}` → `Async{}` and `Async::Task#sleep` → `Kernel#sleep`.

I left the version bump and `releases.md` entry for you to handle as part of your release flow.

## Verification

- Full `sus` suite passes (227 passed / 3 skipped), unchanged from `main`.
- Under `ruby -w`, no deprecation warnings originate from async-http's own code (the only remaining one comes from the external `sus-fixtures-async` gem).
- RuboCop clean.
