### PR TITLE
Expose HTTP protocol names

### DIFF
--- a/lib/async/http/protocol/http.rb
+++ b/lib/async/http/protocol/http.rb
@@ -26,6 +26,12 @@ module Async
 					@http2 = http2
 				end
 				
+				# The names of all supported protocols.
+				# @returns [Array(String)] The supported protocol names.
+				def names
+					(@http2.names + @http1.names).uniq
+				end
+				
 				# Determine if the inbound connection is HTTP/1 or HTTP/2.
 				#
 				# @parameter stream [IO::Stream] The stream to detect the protocol for.

--- a/releases.md
+++ b/releases.md
@@ -1,9 +1,12 @@
 # Releases
 
+## Unreleased
+
+  - Exposed all supported protocol names from the plaintext HTTP protocol negotiator.
+
 ## v0.96.0
 
   - Made `metrics` and `traces` optional runtime dependencies. Applications that use the providers should depend on the corresponding gem and require the provider explicitly.
-  - Exposed all supported protocol names from the plaintext HTTP protocol negotiator.
 
 ## v0.95.1
 

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## v0.96.0
 
   - Made `metrics` and `traces` optional runtime dependencies. Applications that use the providers should depend on the corresponding gem and require the provider explicitly.
+  - Exposed all supported protocol names from the plaintext HTTP protocol negotiator.
 
 ## v0.95.1
 

--- a/test/async/http/protocol/http.rb
+++ b/test/async/http/protocol/http.rb
@@ -14,6 +14,18 @@ describe Async::HTTP::Protocol::HTTP do
 		it "has a default instance" do
 			expect(protocol).to be_a Async::HTTP::Protocol::HTTP
 		end
+		
+		it "exposes the supported protocol names" do
+			expect(subject.names).to be == ["h2", "http/1.1", "http/1.0"]
+		end
+	end
+	
+	with "configured protocols" do
+		let(:protocol) {subject.new(http1: Async::HTTP::Protocol::HTTP11, http2: Async::HTTP::Protocol::HTTP2)}
+		
+		it "exposes their supported protocol names" do
+			expect(protocol.names).to be == ["h2", "http/1.1"]
+		end
 	end
 	
 	with "#protocol_for" do


### PR DESCRIPTION
## Summary

- Expose the complete set of protocol names supported by the plaintext HTTP negotiator.
- Preserve the configured HTTP/2-then-HTTP/1 preference order while removing duplicate names.
- Cover both the default negotiator and a restricted protocol configuration.

This makes `Async::HTTP::Protocol::HTTP.names` consistent with the existing `HTTPS.names` interface and allows integrations to serialize protocol capabilities without depending on Async::HTTP implementation constants.

## Testing

- `bundle exec sus test/async/http/protocol/http.rb` (7 tests, 9 assertions)
- `bundle exec bake test` (229 passed, 3 skipped, 33,904 assertions)
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib` (292/292 definitions)