### PR TITLE
Rewind request bodies before retry

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-pool", "~> 0.11"
 	spec.add_dependency "io-endpoint", "~> 0.14"
 	spec.add_dependency "io-stream", "~> 0.6"
-	spec.add_dependency "protocol-http", "~> 0.62"
+	spec.add_dependency "protocol-http", "~> 0.63", ">= 0.63.1"
 	spec.add_dependency "protocol-http1", "~> 0.39"
 	spec.add_dependency "protocol-http2", "~> 0.26"
 	spec.add_dependency "protocol-url", "~> 0.2"

--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-pool", "~> 0.11"
 	spec.add_dependency "io-endpoint", "~> 0.14"
 	spec.add_dependency "io-stream", "~> 0.6"
-	spec.add_dependency "protocol-http", "~> 0.63", ">= 0.63.1"
+	spec.add_dependency "protocol-http", "~> 0.64"
 	spec.add_dependency "protocol-http1", "~> 0.39"
 	spec.add_dependency "protocol-http2", "~> 0.26"
 	spec.add_dependency "protocol-url", "~> 0.2"

--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -121,7 +121,7 @@ module Async
 						connection = nil
 					end
 					
-					if attempt < @retries
+					if attempt < @retries and request.rewind!
 						retry
 					else
 						raise
@@ -132,7 +132,7 @@ module Async
 						connection = nil
 					end
 					
-					if request.idempotent? and attempt < @retries
+					if attempt < @retries and request.retry!
 						retry
 					else
 						raise

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Rewind request bodies before retrying requests.
+
 ## v0.97.0
 
   - Exposed all supported protocol names from the plaintext HTTP protocol negotiator.

--- a/test/async/http/client.rb
+++ b/test/async/http/client.rb
@@ -14,61 +14,6 @@ require "sus/fixtures/async"
 require "sus/fixtures/async/http"
 
 describe Async::HTTP::Client do
-	class RetryClient < Async::HTTP::Client
-		def initialize(failures)
-			@pool = FakePool.new
-			@protocol = nil
-			@retries = 3
-			@scheme = "https"
-			@authority = "example.com"
-			@failures = failures
-			@chunks = []
-		end
-		
-		attr :chunks
-		
-		class FakePool
-			def acquire
-				Object.new
-			end
-			
-			def release(connection)
-			end
-		end
-		
-		def make_response(request, connection, attempt)
-			@chunks << request.body&.read
-			
-			if failure = @failures.shift
-				raise failure
-			end
-			
-			return Protocol::HTTP::Response[200, {}, ["OK"]]
-		end
-	end
-	
-	with "retries" do
-		it "rewinds idempotent request bodies after ambiguous failures" do
-			client = RetryClient.new([EOFError.new])
-			request = Protocol::HTTP::Request["PUT", "/", {}, ["Hello"]]
-			
-			response = client.call(request)
-			
-			expect(response).to be(:success?)
-			expect(client.chunks).to be == ["Hello", "Hello"]
-		end
-		
-		it "rewinds non-idempotent request bodies after refused requests" do
-			client = RetryClient.new([Protocol::HTTP::RefusedError.new("Request not processed.")])
-			request = Protocol::HTTP::Request["POST", "/", {}, ["Hello"]]
-			
-			response = client.call(request)
-			
-			expect(response).to be(:success?)
-			expect(client.chunks).to be == ["Hello", "Hello"]
-		end
-	end
-	
 	with "basic server" do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		

--- a/test/async/http/client.rb
+++ b/test/async/http/client.rb
@@ -14,6 +14,61 @@ require "sus/fixtures/async"
 require "sus/fixtures/async/http"
 
 describe Async::HTTP::Client do
+	class RetryClient < Async::HTTP::Client
+		def initialize(failures)
+			@pool = FakePool.new
+			@protocol = nil
+			@retries = 3
+			@scheme = "https"
+			@authority = "example.com"
+			@failures = failures
+			@chunks = []
+		end
+		
+		attr :chunks
+		
+		class FakePool
+			def acquire
+				Object.new
+			end
+			
+			def release(connection)
+			end
+		end
+		
+		def make_response(request, connection, attempt)
+			@chunks << request.body&.read
+			
+			if failure = @failures.shift
+				raise failure
+			end
+			
+			return Protocol::HTTP::Response[200, {}, ["OK"]]
+		end
+	end
+	
+	with "retries" do
+		it "rewinds idempotent request bodies after ambiguous failures" do
+			client = RetryClient.new([EOFError.new])
+			request = Protocol::HTTP::Request["PUT", "/", {}, ["Hello"]]
+			
+			response = client.call(request)
+			
+			expect(response).to be(:success?)
+			expect(client.chunks).to be == ["Hello", "Hello"]
+		end
+		
+		it "rewinds non-idempotent request bodies after refused requests" do
+			client = RetryClient.new([Protocol::HTTP::RefusedError.new("Request not processed.")])
+			request = Protocol::HTTP::Request["POST", "/", {}, ["Hello"]]
+			
+			response = client.call(request)
+			
+			expect(response).to be(:success?)
+			expect(client.chunks).to be == ["Hello", "Hello"]
+		end
+	end
+	
 	with "basic server" do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		

--- a/test/async/http/client/retry.rb
+++ b/test/async/http/client/retry.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/client"
+
+class RetryClient < Async::HTTP::Client
+	def initialize(failures)
+		@pool = FakePool.new
+		@protocol = nil
+		@retries = 3
+		@scheme = "https"
+		@authority = "example.com"
+		@failures = failures
+		@chunks = []
+	end
+	
+	attr :chunks
+	
+	class FakePool
+		def acquire
+			Object.new
+		end
+		
+		def release(connection)
+		end
+	end
+	
+	def make_response(request, connection, attempt)
+		@chunks << request.body&.read
+		
+		if failure = @failures.shift
+			raise failure
+		end
+		
+		return Protocol::HTTP::Response[200, {}, ["OK"]]
+	end
+end
+
+describe Async::HTTP::Client do
+	with "retries" do
+		it "rewinds idempotent request bodies after ambiguous failures" do
+			client = RetryClient.new([EOFError.new])
+			request = Protocol::HTTP::Request["PUT", "/", {}, ["Hello"]]
+			
+			response = client.call(request)
+			
+			expect(response).to be(:success?)
+			expect(client.chunks).to be == ["Hello", "Hello"]
+		end
+		
+		it "rewinds non-idempotent request bodies after refused requests" do
+			client = RetryClient.new([Protocol::HTTP::RefusedError.new("Request not processed.")])
+			request = Protocol::HTTP::Request["POST", "/", {}, ["Hello"]]
+			
+			response = client.call(request)
+			
+			expect(response).to be(:success?)
+			expect(client.chunks).to be == ["Hello", "Hello"]
+		end
+	end
+end


### PR DESCRIPTION
## Summary

- Use `request.rewind!` before retrying requests known not to have been processed (`Protocol::HTTP::RefusedError`).
- Use `request.retry!` before retrying ambiguous connection failures.
- Require released `protocol-http ~> 0.64` for the retry preparation API.
- Add focused client retry tests proving consumed request bodies are resent on retry.

## Testing

- `bundle exec sus test/async/http/client.rb`
- `bundle exec sus`

Full suite result: 231 passed, 3 skipped.