### PR TITLE
Probe idle HTTP/1 connections before reuse

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async", ">= 2.35.1"
 	spec.add_dependency "async-pool", "~> 0.11"
 	spec.add_dependency "io-endpoint", "~> 0.14"
-	spec.add_dependency "io-stream", "~> 0.6"
+	spec.add_dependency "io-stream", "~> 0.14"
 	spec.add_dependency "protocol-http", "~> 0.64"
 	spec.add_dependency "protocol-http1", "~> 0.39"
 	spec.add_dependency "protocol-http2", "~> 0.26"

--- a/gems.rb
+++ b/gems.rb
@@ -42,6 +42,7 @@ group :test do
 	
 	gem "sus-fixtures-async"
 	gem "sus-fixtures-async-http", "~> 0.8"
+	gem "sus-fixtures-console"
 	gem "sus-fixtures-openssl"
 	gem "sus-fixtures-benchmark"
 	

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2025, by Samuel Williams.
+# Copyright, 2018-2026, by Samuel Williams.
 
 require_relative "request"
 require_relative "response"
 
 require "protocol/http1"
 require "protocol/http/peer"
+require "openssl"
 
 module Async
 	module HTTP
@@ -67,7 +68,23 @@ module Async
 					
 					# Can we use this connection to make requests?
 					def viable?
-						self.idle? && @stream&.readable?
+						unless self.idle?
+							return false
+						end
+						
+						unless @stream
+							return false
+						end
+						
+						# Application data on an idle HTTP/1 connection is unexpected. A
+						# non-blocking peek also processes an EOF or TLS close notification.
+						if @stream.peek_partial(1)
+							return false
+						end
+						
+						return @stream.readable?
+					rescue IOError, SystemCallError, OpenSSL::SSL::SSLError
+						return false
 					end
 					
 					# @returns [Boolean] Whether the connection can be reused for another request.

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -83,7 +83,9 @@ module Async
 						end
 						
 						return @stream.readable?
-					rescue IOError, SystemCallError, OpenSSL::SSL::SSLError
+					rescue => error
+						Console.debug(self, "Connection viability probe failed!", exception: error)
+						
 						return false
 					end
 					

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -8,7 +8,6 @@ require_relative "response"
 
 require "protocol/http1"
 require "protocol/http/peer"
-require "openssl"
 
 module Async
 	module HTTP

--- a/lib/async/http/protocol/http1/connection.rb
+++ b/lib/async/http/protocol/http1/connection.rb
@@ -75,8 +75,7 @@ module Async
 							return false
 						end
 						
-						# Application data on an idle HTTP/1 connection is unexpected. A
-						# non-blocking peek also processes an EOF or TLS close notification.
+						# `nil` indicates that the connection has no data, but is still alive. An empty string means the connection is closed, while a non-empty string indicates application data on a idle HTTP/1 connection, both are failure cases.
 						if @stream.peek_partial(1)
 							return false
 						end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Probe idle HTTP/1 connections before reuse, avoiding requests on connections already closed by the peer.
+
 ## v0.98.0
 
   - Rewind request bodies before retrying requests.

--- a/test/async/http/protocol/http1/connection.rb
+++ b/test/async/http/protocol/http1/connection.rb
@@ -8,11 +8,13 @@ require "async/http/protocol/http1/connection"
 require "io/stream"
 
 require "sus/fixtures/async/reactor_context"
+require "sus/fixtures/console"
 require "sus/fixtures/openssl/verified_certificate_context"
 require "sus/fixtures/openssl/valid_certificate_context"
 
 describe Async::HTTP::Protocol::HTTP1::Connection do
 	include Sus::Fixtures::Async::ReactorContext
+	include Sus::Fixtures::Console::CapturedLogger
 	include Sus::Fixtures::OpenSSL::VerifiedCertificateContext
 	include Sus::Fixtures::OpenSSL::ValidCertificateContext
 	
@@ -96,6 +98,12 @@ describe Async::HTTP::Protocol::HTTP1::Connection do
 		@sockets.first.wait_readable(1)
 		
 		expect(connection).not.to be(:viable?)
+		expect_console.to have_logged(
+			severity: be == :debug,
+			subject: be_equal(connection),
+			message: be == "Connection viability probe failed!",
+			event: have_keys(type: be == :failure)
+		)
 	end
 	
 	it "is not viable when application data is pending while idle" do

--- a/test/async/http/protocol/http1/connection.rb
+++ b/test/async/http/protocol/http1/connection.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http1/connection"
+
+require "io/stream"
+
+require "sus/fixtures/async/reactor_context"
+require "sus/fixtures/openssl/verified_certificate_context"
+require "sus/fixtures/openssl/valid_certificate_context"
+
+describe Async::HTTP::Protocol::HTTP1::Connection do
+	include Sus::Fixtures::Async::ReactorContext
+	include Sus::Fixtures::OpenSSL::VerifiedCertificateContext
+	include Sus::Fixtures::OpenSSL::ValidCertificateContext
+	
+	before do
+		listener = TCPServer.new("localhost", 0)
+		port = listener.local_address.ip_port
+		
+		@sockets = [
+			TCPSocket.new("localhost", port),
+			listener.accept,
+		]
+		listener.close
+		
+		client_socket = OpenSSL::SSL::SSLSocket.new(@sockets[0], client_context)
+		server_socket = OpenSSL::SSL::SSLSocket.new(@sockets[1], server_context)
+		
+		client_socket.sync_close = true
+		server_socket.sync_close = true
+		
+		accept = reactor.async do
+			server_socket.accept
+		end
+		
+		connect = reactor.async do
+			client_socket.connect
+		end
+		
+		[accept, connect].each(&:wait)
+		
+		@client = IO::Stream::Buffered.wrap(client_socket)
+		@server = IO::Stream::Buffered.wrap(server_socket)
+		@connection = subject.new(@client, "HTTP/1.1")
+	end
+	
+	after do
+		@client&.close
+		@server&.close
+		
+		@sockets.each do |socket|
+			unless socket.closed?
+				socket.close
+			end
+		end
+	end
+	
+	attr :client
+	attr :server
+	attr :connection
+	
+	it "remains viable when an idle TLS connection would block" do
+		expect(connection).to be(:viable?)
+	end
+	
+	it "is not viable while active" do
+		connection.state = :open
+		
+		expect(connection).not.to be(:viable?)
+	end
+	
+	it "is not viable without a stream" do
+		connection = subject.new(nil, "HTTP/1.1")
+		
+		expect(connection).not.to be(:viable?)
+	end
+	
+	it "is not viable after a TLS close notification" do
+		closing = reactor.async do
+			server.close
+		end
+		
+		@sockets.first.wait_readable(1)
+		
+		expect(connection).not.to be(:viable?)
+		closing.wait
+	end
+	
+	it "is not viable after an abrupt TLS disconnect" do
+		@sockets.last.close
+		@server = nil
+		
+		@sockets.first.wait_readable(1)
+		
+		expect(connection).not.to be(:viable?)
+	end
+	
+	it "is not viable when application data is pending while idle" do
+		server.write("H")
+		server.flush
+		
+		@sockets.first.wait_readable(1)
+		
+		expect(connection).not.to be(:viable?)
+		expect(client.read(1)).to be == "H"
+	end
+end

--- a/test/async/http/ssl.rb
+++ b/test/async/http/ssl.rb
@@ -55,7 +55,7 @@ describe Async::HTTP::Server do
 		end
 		
 		with "an idle connection closed by the server" do
-			include Sus::Fixtures::Console::CapturedLogger
+			include Sus::Fixtures::Console::NullLogger
 			
 			let(:connections) {[]}
 			

--- a/test/async/http/ssl.rb
+++ b/test/async/http/ssl.rb
@@ -8,8 +8,9 @@ require "async/http/client"
 require "async/http/endpoint"
 
 require "sus/fixtures/async"
-require "sus/fixtures/openssl"
 require "sus/fixtures/async/http"
+require "sus/fixtures/console"
+require "sus/fixtures/openssl"
 
 describe Async::HTTP::Server do
 	include Sus::Fixtures::Async::HTTP::ServerContext
@@ -54,16 +55,9 @@ describe Async::HTTP::Server do
 		end
 		
 		with "an idle connection closed by the server" do
-			let(:connections) {[]}
+			include Sus::Fixtures::Console::CapturedLogger
 			
-			def around
-				level = Console.logger.level
-				Console.logger.fatal!
-				
-				super
-			ensure
-				Console.logger.level = level
-			end
+			let(:connections) {[]}
 			
 			let(:app) do
 				connections = self.connections

--- a/test/async/http/ssl.rb
+++ b/test/async/http/ssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2025, by Samuel Williams.
+# Copyright, 2018-2026, by Samuel Williams.
 
 require "async/http/server"
 require "async/http/client"
@@ -51,6 +51,51 @@ describe Async::HTTP::Server do
 			
 			expect(response).to be(:success?)
 			expect(response.read).to be == "Hello World!"
+		end
+		
+		with "an idle connection closed by the server" do
+			let(:connections) {[]}
+			
+			def around
+				level = Console.logger.level
+				Console.logger.fatal!
+				
+				super
+			ensure
+				Console.logger.level = level
+			end
+			
+			let(:app) do
+				connections = self.connections
+				
+				Protocol::HTTP::Middleware.for do |request|
+					connections << request.connection
+					
+					Protocol::HTTP::Response[200, {}, ["Hello World!"]]
+				end
+			end
+			
+			it "uses a fresh connection for a non-idempotent request" do
+				first_response = client.get("/")
+				first_response.read
+				first_connection = first_response.connection
+				
+				closing = reactor.async do
+					connections.first.close
+				end
+				
+				first_connection.stream.io.to_io.wait_readable(1)
+				
+				second_response = client.post("/")
+				
+				expect(second_response).to be(:success?)
+				expect(second_response.connection).not.to be == first_connection
+				expect(connections.size).to be == 2
+				closing.wait
+			ensure
+				first_response&.close
+				second_response&.close
+			end
 		end
 	end
 end


### PR DESCRIPTION
# TL;DR

Probe idle HTTP/1 connections before the pool reuses them, so a peer shutdown that is already observable does not turn a non-idempotent request into an `EOFError`.

# Context

An underlying socket can be readable because EOF or a TLS `close_notify` is pending. The existing `Readable#readable?` check intentionally does not consume the layered transport, so it cannot distinguish that state from a connection on which another read may eventually succeed.

`io-stream` 0.14 introduced `Readable#peek_partial`, which can perform one non-blocking read through TLS while preserving any application bytes in the stream buffer. HTTP/1 can safely use that primitive while idle because it has no concurrent reader.

Closes https://github.com/socketry/async-http/issues/223

# Changes

- require `io-stream ~> 0.14`
- use `peek_partial(1)` in the HTTP/1 connection viability check
- reject application bytes that arrive while the HTTP/1 connection is idle
- treat EOF, TLS shutdown, connection resets, and other transport failures observed by the probe as non-viable
- leave HTTP/2 viability unchanged because its background reader owns transport reads
- cover idle/open TLS, clean `close_notify`, abrupt TLS disconnect, pending buffered application data, inactive connections, and absent streams
- add an end-to-end regression where a server closes a pooled TLS connection and a subsequent non-idempotent POST succeeds on a fresh connection

# Tophatting

The end-to-end regression was also run against the previous `viable?` implementation and reproduced the reported `EOFError` from `Protocol::HTTP1::Connection#read_response_line`.

Validation on Ruby 3.4.4:

- `bundle exec sus test/async/http/ssl.rb test/async/http/protocol/http1/connection.rb` — 8 tests, 12 assertions
- `bundle exec bake test` — 236 passed, 3 skipped, 34,728 assertions
- `bundle exec rubocop` — 127 files, no offenses
- `bundle exec bake decode:index:coverage lib` — 292/292 public definitions documented
- coverage run exercised every executable line added to `viable?`
