### PR TITLE
Retry remote HTTP/2 internal errors

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-pool", "~> 0.11"
 	spec.add_dependency "io-endpoint", "~> 0.14"
 	spec.add_dependency "io-stream", "~> 0.14"
-	spec.add_dependency "protocol-http", "~> 0.64"
+	spec.add_dependency "protocol-http", "~> 0.66"
 	spec.add_dependency "protocol-http1", "~> 0.39"
 	spec.add_dependency "protocol-http2", "~> 0.26"
 	spec.add_dependency "protocol-url", "~> 0.2"

--- a/lib/async/http/client.rb
+++ b/lib/async/http/client.rb
@@ -9,6 +9,7 @@ require "io/endpoint"
 require "async/pool/controller"
 
 require "protocol/http/body/completable"
+require "protocol/http/error"
 require "protocol/http/methods"
 
 require_relative "protocol"
@@ -126,7 +127,7 @@ module Async
 					else
 						raise
 					end
-				rescue SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE
+				rescue ::Protocol::HTTP::RemoteError, SocketError, IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE
 					if connection
 						@pool.release(connection)
 						connection = nil

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -122,6 +122,12 @@ module Async
 							if @exception
 								raise @exception
 							end
+						rescue ::Protocol::HTTP2::StreamError => error
+							if error.code == ::Protocol::HTTP2::Error::INTERNAL_ERROR
+								raise ::Protocol::HTTP::RemoteError, error.message
+							end
+							
+							raise
 						end
 						
 						# Called when the stream is closed.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Retry safe requests when a remote HTTP/2 endpoint resets the stream with `INTERNAL_ERROR` before returning a response.
+
 ## v0.98.1
 
   - Probe idle HTTP/1 connections before reuse, avoiding requests on connections already closed by the peer.

--- a/test/async/http/client/retry.rb
+++ b/test/async/http/client/retry.rb
@@ -50,6 +50,27 @@ describe Async::HTTP::Client do
 			expect(client.chunks).to be == ["Hello", "Hello"]
 		end
 		
+		it "rewinds idempotent request bodies after remote failures" do
+			client = RetryClient.new([Protocol::HTTP::RemoteError.new("Remote endpoint failed.")])
+			request = Protocol::HTTP::Request["PUT", "/", {}, ["Hello"]]
+			
+			response = client.call(request)
+			
+			expect(response).to be(:success?)
+			expect(client.chunks).to be == ["Hello", "Hello"]
+		end
+		
+		it "does not retry non-idempotent requests after remote failures" do
+			client = RetryClient.new([Protocol::HTTP::RemoteError.new("Remote endpoint failed.")])
+			request = Protocol::HTTP::Request["POST", "/", {}, ["Hello"]]
+			
+			expect do
+				client.call(request)
+			end.to raise_exception(Protocol::HTTP::RemoteError)
+			
+			expect(client.chunks).to be == ["Hello"]
+		end
+		
 		it "rewinds non-idempotent request bodies after refused requests" do
 			client = RetryClient.new([Protocol::HTTP::RefusedError.new("Request not processed.")])
 			request = Protocol::HTTP::Request["POST", "/", {}, ["Hello"]]

--- a/test/async/http/protocol/http2/connection_close_with_active_streams.rb
+++ b/test/async/http/protocol/http2/connection_close_with_active_streams.rb
@@ -49,6 +49,26 @@ describe Async::HTTP::Protocol::HTTP2 do
 			end.wait
 		end
 		
+		it "maps a remote internal error while waiting for headers" do
+			Async do |task|
+				client_connection = Async::HTTP::Protocol::HTTP2::Client.new(client_stream)
+				client_connection.open!
+				
+				response = client_connection.create_response
+				response.stream.close!(Protocol::HTTP2::INTERNAL_ERROR)
+				
+				expect do
+					client_connection.read_response(response)
+				end.to raise_exception(Protocol::HTTP::RemoteError).and(
+					have_attributes(
+						cause: be_a(Protocol::HTTP2::StreamError).and(
+							have_attributes(code: be == Protocol::HTTP2::INTERNAL_ERROR)
+						)
+					)
+				)
+			end.wait
+		end
+		
 		it "does not raise error when connection closes without active streams" do
 			Async do |task|
 				# Create client connection


### PR DESCRIPTION
## Summary

- Map HTTP/2 `StreamError(INTERNAL_ERROR)` to `Protocol::HTTP::RemoteError` while waiting for response headers.
- Preserve the original `StreamError`, including its HTTP/2 error code, as `Exception#cause`.
- Retry `RemoteError` using `Request#retry!`, so only retry-safe methods with rewindable bodies are resent.
- Require `protocol-http ~> 0.66` for `RemoteError`.

The translation occurs in `HTTP2::Client#read_response`, where the protocol-specific response failure becomes the outcome of the abstract HTTP client call. This establishes the native cause chain without changing the low-level protocol-http2 callback lifecycle. Resets received after a response has already been returned remain visible while reading the response body and are not transparently retried.

Closes #231.

## Testing

- Focused retry and HTTP/2 mapping tests: 7 passed, 23 assertions
- Full suite: 241 passed, 3 skipped, 33,560 assertions
- RuboCop on changed Ruby files: no offenses