### PR TITLE
Close HTTP/2 request queue

### DIFF
--- a/lib/async/http/protocol/http2/server.rb
+++ b/lib/async/http/protocol/http2/server.rb
@@ -41,11 +41,7 @@ module Async
 					
 					# Close the server connection and stop accepting requests.
 					def close(error = nil)
-						if @requests
-							# Stop the request loop:
-							@requests.enqueue(nil)
-							@requests = nil
-						end
+						@requests.close
 						
 						super
 					end
@@ -57,7 +53,7 @@ module Async
 						task.annotate("Reading #{version} requests for #{self.class}.")
 						
 						# It's possible the connection has died before we get here...
-						@requests&.async do |task, request|
+						@requests.async do |task, request|
 							task.annotate("Incoming request: #{request.method} #{request.path.inspect}.")
 							
 							response = nil

--- a/test/async/http/protocol/http2/server.rb
+++ b/test/async/http/protocol/http2/server.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http2"
+require "sus/fixtures/async/scheduler_context"
+require "socket"
+
+describe Async::HTTP::Protocol::HTTP2::Server do
+	include Sus::Fixtures::Async::SchedulerContext
+	
+	let(:sockets) {Socket.pair(Socket::PF_UNIX, Socket::SOCK_STREAM)}
+	let(:stream) {IO::Stream(sockets.first)}
+	let(:server) {subject.new(stream)}
+	
+	it "closes the request queue" do
+		request = Object.new
+		server.requests.enqueue(request)
+		
+		server.close
+		
+		expect(server.requests).to be(:closed?)
+		expect(server.requests.dequeue).to be == request
+		expect(server.requests.dequeue).to be_nil
+		
+		expect do
+			server.requests.enqueue(Object.new)
+		end.to raise_exception(Async::Queue::ClosedError)
+	end
+end


### PR DESCRIPTION
Use `Async::Queue#close` to stop the HTTP/2 server request loop instead of enqueueing a `nil` sentinel and discarding the queue reference.

Closing preserves already queued requests, causes the consumer to receive `nil` once drained, and rejects late producers with `Async::Queue::ClosedError`.

Includes a focused test for the queue shutdown semantics.

Tests: 242 passed, 3 skipped. RuboCop: 128 files inspected, no offenses.