### PR TITLE
Map HTTP/2 body INTERNAL_ERROR to RemoteError

### DIFF
--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -4,6 +4,8 @@
 # Copyright, 2020-2024, by Samuel Williams.
 
 require "protocol/http/body/writable"
+require "protocol/http/error"
+require "protocol/http2/error"
 
 module Async
 	module HTTP
@@ -41,6 +43,12 @@ module Async
 						end
 						
 						return chunk
+					rescue ::Protocol::HTTP2::StreamError => error
+						if error.code == ::Protocol::HTTP2::Error::INTERNAL_ERROR
+							raise ::Protocol::HTTP::RemoteError, error.message
+						end
+						
+						raise
 					end
 				end
 			end

--- a/test/async/http/protocol/http2/connection_close_with_active_streams.rb
+++ b/test/async/http/protocol/http2/connection_close_with_active_streams.rb
@@ -69,6 +69,31 @@ describe Async::HTTP::Protocol::HTTP2 do
 			end.wait
 		end
 		
+		it "maps a remote internal error while reading the response body" do
+			Async do |task|
+				client_connection = Async::HTTP::Protocol::HTTP2::Client.new(client_stream)
+				client_connection.open!
+				
+				response = client_connection.create_response
+				request = Protocol::HTTP::Request.new("https", "example.com", "GET", "/")
+				client_connection.write_request(response, request)
+				response.stream.receive_initial_headers([[":status", "200"]], false)
+				
+				client_connection.read_response(response)
+				response.stream.close!(Protocol::HTTP2::INTERNAL_ERROR)
+				
+				expect do
+					response.body.read
+				end.to raise_exception(Protocol::HTTP::RemoteError).and(
+					have_attributes(
+						cause: be_a(Protocol::HTTP2::StreamError).and(
+							have_attributes(code: be == Protocol::HTTP2::INTERNAL_ERROR)
+						)
+					)
+				)
+			end.wait
+		end
+		
 		it "does not raise error when connection closes without active streams" do
 			Async do |task|
 				# Create client connection


### PR DESCRIPTION
## Summary

- map an HTTP/2 stream INTERNAL_ERROR raised while reading a response body to Protocol::HTTP::RemoteError
- preserve the original Protocol::HTTP2::StreamError as the implicit exception cause
- add coverage for the headers-then-reset ordering reported in the issue

This complements the pre-response mapping added in #232. Once response headers have resolved readiness, a later reset surfaces from the body and cannot safely be retried inside Async::HTTP::Client. Normalizing it as RemoteError lets integrations apply their own retry policy.

## Testing

- focused HTTP/2 regression: 4 tests, 20 assertions
- RuboCop: 128 files, no offenses
- full suite: 243 passed, 3 skipped; one unrelated live-network test errored and reproduced independently as ECONNRESET during SSL_connect

Fixes #231