### PR TITLE
Respond with 414 when a line exceeds the maximum line length

### DIFF
--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -61,6 +61,10 @@ module Async
 						end
 						
 						return request
+					rescue ::Protocol::HTTP1::LineLengthError
+						# We don't know whether the request line or a header line was too long, so we respond with the more common case (URI Too Long):
+						fail_request(414)
+						raise
 					rescue ::Protocol::HTTP1::BadRequest
 						fail_request(400)
 						# Conceivably we could retry here, but we don't really know how bad the error is, so it's better to just fail:

--- a/test/async/http/protocol/http11.rb
+++ b/test/async/http/protocol/http11.rb
@@ -103,6 +103,23 @@ describe Async::HTTP::Protocol::HTTP11 do
 				
 				expect(response.status).to be == 400
 			end
+			
+			with "maximum line length" do
+				let(:maximum_line_length) {1024}
+				let(:protocol) {subject.new(maximum_line_length: maximum_line_length)}
+				
+				it "should fail with 414 when the request line is too long" do
+					response = client.get("/?q=#{"a" * maximum_line_length}")
+					
+					expect(response.status).to be == 414
+				end
+				
+				it "should fail with 414 when a header line is too long" do
+					response = client.get("/", {"x-padding" => "a" * maximum_line_length})
+					
+					expect(response.status).to be == 414
+				end
+			end
 		end
 		
 		with "head request" do


### PR DESCRIPTION
Fixes #237.

Previously, when a request line or header line exceeded `maximum_line_length`, `LineLengthError` propagated past `next_request` (it doesn't include the `BadRequest` marker), so the server closed the connection without writing anything and the peer saw an unexplained EOF.

This PR rescues `LineLengthError` in `next_request` and uses the existing `fail_request` path to respond with 414 before re-raising, matching the existing `BadRequest` → 400 handling. The request-line and header-line cases can't be distinguished at the rescue site, so both get 414 as the more common case — happy to split the error by phase in protocol-http1 and map 414/431 instead if you'd prefer that precision.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).