### PR TITLE
Handle HTTP/1 remote disconnects

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "io-endpoint", "~> 0.18"
 	spec.add_dependency "io-stream", "~> 0.14"
 	spec.add_dependency "protocol-http", "~> 0.66"
-	spec.add_dependency "protocol-http1", "~> 0.39"
+	spec.add_dependency "protocol-http1", "~> 0.41"
 	spec.add_dependency "protocol-http2", "~> 0.26"
 	spec.add_dependency "protocol-url", "~> 0.2"
 end

--- a/lib/async/http/protocol/http1/server.rb
+++ b/lib/async/http/protocol/http1/server.rb
@@ -161,6 +161,9 @@ module Async
 									# Do not remove this line or you will unleash the gods of concurrency hell.
 									task.yield
 								end
+							rescue ::Protocol::HTTP::RemoteError => error
+								Console.debug(self, "Remote endpoint disconnected!", exception: error)
+								return
 							rescue => error
 								# We store error (as a local variable) for later use in the ensure block.
 								raise

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Handle remote disconnects in `Async::HTTP::Protocol::HTTP1::Server#each` without reporting them as server failures.
+
 ## v0.100.0
 
   - Added transport-neutral TLS configuration support to `Async::HTTP::Endpoint`.

--- a/test/async/http/protocol/http1/server.rb
+++ b/test/async/http/protocol/http1/server.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http1/server"
+
+require "async/promise"
+require "protocol/http/body/buffered"
+require "protocol/http/body/wrapper"
+require "sus/fixtures/async/reactor_context"
+
+describe Async::HTTP::Protocol::HTTP1::Server do
+	include Sus::Fixtures::Async::ReactorContext
+	
+	let(:server_class) do
+		Class.new(subject) do
+			attr :next_request_count
+			
+			def initialize(error = nil)
+				super(nil, "HTTP/1.1")
+				
+				@error = error
+				@next_request_count = 0
+				@request = Async::HTTP::Protocol::HTTP1::Request.new(
+					self,
+					nil,
+					"localhost",
+					"GET",
+					"/",
+					"HTTP/1.1",
+					Protocol::HTTP::Headers.new,
+					nil,
+				)
+			end
+			
+			def next_request
+				@next_request_count += 1
+				
+				request = @request
+				@request = nil
+				return request
+			end
+			
+			def write_response(...)
+			end
+			
+			def write_body(...)
+				if @error
+					raise Protocol::HTTP::RemoteError, @error.message, cause: @error
+				end
+			end
+			
+			def hijacked?
+				false
+			end
+		end
+	end
+	
+	let(:body_closed) {Async::Promise.new}
+	
+	let(:body) do
+		body_closed = self.body_closed
+		
+		Class.new(Protocol::HTTP::Body::Wrapper) do
+			define_method(:close) do |error = nil|
+				body_closed.resolve(error)
+				super(error)
+			end
+		end.new(Protocol::HTTP::Body::Buffered.wrap("Hello World"))
+	end
+	
+	[Errno::EPIPE, Errno::ECONNRESET].each do |error_class|
+		it "handles #{error_class} reported as a remote error", unique: error_class.name do
+			error = error_class.new
+			server = server_class.new(error)
+			
+			server.each do
+				Protocol::HTTP::Response[200, {}, body]
+			end
+			
+			expect(server.next_request_count).to be == 1
+			
+			expect(body_closed.wait).to be_a(Protocol::HTTP::RemoteError).and(
+				have_attributes(cause: be_equal(error))
+			)
+		end
+	end
+	
+	it "propagates errors raised while generating the response" do
+		server = server_class.new
+		
+		expect do
+			server.each do
+				raise Errno::EPIPE
+			end
+		end.to raise_exception(Errno::EPIPE)
+	end
+end


### PR DESCRIPTION
## Summary

- Treat `Protocol::HTTP::RemoteError` in the HTTP/1 server loop as a normal remote disconnect.
- Log the disconnect at debug level and terminate the affected connection.
- Close the response body with the original remote error.
- Continue to propagate unrelated exceptions such as raw application `EPIPE` failures.

Depends on socketry/protocol-http1#58, which maps connection-level `EPIPE` and `ECONNRESET` failures to `Protocol::HTTP::RemoteError` and prevents connection reuse.

## Testing

- `bundle exec bake test`
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib`