### PR TITLE
Make CONNECT proxy request tasks `transient: true` to prevent blocking the parent task.

### DIFF
--- a/lib/async/http/protocol/http1/client.rb
+++ b/lib/async/http/protocol/http1/client.rb
@@ -61,7 +61,8 @@ module Async
 									self.close(error)
 								end
 							elsif request.connect?
-								task.async(annotation: "Tunnneling request...") do
+								# Transient, like the pipe tasks this tunnel feeds: an open tunnel should not keep the parent task (or the reactor) from finishing.
+								task.async(transient: true, annotation: "Tunneling request...") do
 									write_tunnel_body(@version, body)
 								rescue => error
 									self.close(error)

--- a/lib/async/http/protocol/http2/output.rb
+++ b/lib/async/http/protocol/http2/output.rb
@@ -29,13 +29,16 @@ module Async
 					attr :trailer
 					
 					# Start an asynchronous task to write the body to the stream.
-					def start(parent: Task.current)
+					#
+					# @parameter parent [Async::Task] The parent task to run the output task under.
+					# @parameter transient [Boolean] Whether the output task should be transient — a tunnel body (e.g. CONNECT) lives as long as the tunnel, and should not keep the parent task from finishing.
+					def start(parent: Task.current, transient: false)
 						raise "Task already started!" if @task
 						
 						if @body.stream?
-							@task = parent.async(&self.method(:stream))
+							@task = parent.async(transient: transient, &self.method(:stream))
 						else
-							@task = parent.async(&self.method(:passthrough))
+							@task = parent.async(transient: transient, &self.method(:passthrough))
 						end
 					end
 					

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -260,7 +260,8 @@ module Async
 								raise ::Protocol::HTTP::RefusedError
 							end
 							
-							@stream.send_body(request.body, trailer)
+							# A CONNECT request's body streams the tunnel for as long as the tunnel lives — it must not keep the parent task from finishing:
+							@stream.send_body(request.body, trailer, transient: request.connect?)
 						end
 					end
 				end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -132,10 +132,10 @@ module Async
 					end
 					
 					# Set the body and begin sending it.
-					def send_body(body, trailer = nil)
+					def send_body(body, trailer = nil, transient: false)
 						@output = Output.new(self, body, trailer)
 						
-						@output.start
+						@output.start(transient: transient)
 					end
 					
 					# Called when the output terminates normally.

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - CONNECT tunnels no longer keep the task which opened them, or the reactor, from finishing.
   - Requests assigned to an HTTP/2 connection which has already closed are refused before being written, allowing them to be retried safely.
   - HTTP/2 connections which received a graceful `GOAWAY` are removed from availability immediately, but remain in the pool until the server has finished answering the streams it accepted. The connection is closed after its final user releases it, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
 

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -114,6 +114,26 @@ AProxy = Sus::Shared("a proxy") do
 			
 			expect(proxy.client.pool).to be(:empty?)
 		end
+		
+		it "does not prevent the connecting task from finishing" do
+			proxy = Async::HTTP::Proxy.tcp(client, "localhost", 1)
+			
+			task = Async do
+				proxy.connect
+			end
+			
+			peer = task.wait
+			
+			# The task has no non-transient children (such as the tunnel's upload task), so it is finished:
+			expect(task).to be(:finished?)
+			
+			# The tunnel remains open in both directions after its connecting task has finished:
+			peer.write(data)
+			expect(peer.read(data.bytesize)).to be == data
+		ensure
+			peer&.close
+			proxy&.close
+		end
 	end
 	
 	with "proxied client" do


### PR DESCRIPTION
- HTTP/1: spawn the tunnel body task with `transient: true` (and fix the "Tunnneling" typo).
- HTTP/2: thread `transient: request.connect?` from `send_request` through `Stream#send_body` into `Output#start`, so only CONNECT bodies are transient — a normal request body must still be written in full even if the parent finishes early.

The new test in test/async/http/proxy.rb abandons a tunnel that is open in both directions and asserts the connecting task is `finished?` after `wait`. It failed for HTTP/1.0, HTTP/1.1 and HTTP/2 before this change.

Fixes the remaining hangs behind socketry/async-http-faraday#59: a Faraday request through `proxy` on the async adapter completed but never returned, because the adapter's `Sync` could not outlive the pooled tunnel.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
