### PR TITLE
Do not close HTTP/2 connections while a graceful GOAWAY is being drained

### DIFF
--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.3"
 	
 	spec.add_dependency "async", ">= 2.35.1"
-	spec.add_dependency "async-pool", "~> 0.11"
+	spec.add_dependency "async-pool", "~> 0.12"
 	spec.add_dependency "io-endpoint", "~> 0.18"
 	spec.add_dependency "io-stream", "~> 0.14"
 	spec.add_dependency "protocol-http", "~> 0.66"

--- a/async-http.gemspec
+++ b/async-http.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "io-stream", "~> 0.14"
 	spec.add_dependency "protocol-http", "~> 0.66"
 	spec.add_dependency "protocol-http1", "~> 0.41"
-	spec.add_dependency "protocol-http2", "~> 0.26"
+	spec.add_dependency "protocol-http2", "~> 0.27"
 	spec.add_dependency "protocol-url", "~> 0.2"
 end

--- a/lib/async/http/protocol/http2/client.rb
+++ b/lib/async/http/protocol/http2/client.rb
@@ -34,6 +34,9 @@ module Async
 					
 					# Used by the client to send requests to the remote server.
 					def call(request)
+						# The remote peer has sent a GOAWAY frame, so it will not process any new streams on this connection. The request has not been sent yet, so it is safe to retry it on a new connection, even if it is not idempotent. This is checked first, because a connection with no streams left to drain is closed by the GOAWAY itself.
+						raise ::Protocol::HTTP::RefusedError, "Connection is going away!" if self.goaway_received?
+						
 						raise ::Protocol::HTTP2::Error, "Connection closed!" if self.closed?
 						
 						response = create_response

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -87,15 +87,31 @@ module Async
 					end
 					
 					# Close the connection and stop the background reader.
+					#
+					# If the remote peer sent a graceful GOAWAY frame, the streams it accepted are still being processed and their responses are still on the way. Closing the connection now would fail those requests, even though the remote peer has already processed them. Instead we defer: the background reader closes the connection once the last stream completes. An explicit error still closes the connection immediately.
 					def close(error = nil)
-						# Ensure the reader task is stopped.
-						if @reader
-							reader = @reader
+						if reader = @reader
+							# Only the background reader can drain the connection, so if it is not running, there is nothing to wait for:
+							return self if error.nil? and self.draining?
+							
 							@reader = nil
-							reader.stop
+							
+							# The reader task can close the connection itself, e.g. when the last stream completes and the connection is released back to the pool. Stopping it here would cancel the current task in the middle of this method, leaving the underlying stream open, so we let it unwind by itself: `closed?` is now true, so the read loop exits.
+							reader.stop unless reader.current?
 						end
 						
 						super
+					end
+					
+					# The connection has finished draining the streams which the remote peer accepted before its graceful GOAWAY.
+					#
+					# The last of those streams can complete on the sending side, in a task other than the background reader - the response arrived first and the request body was still being written. The reader is then parked in a blocking read and will never notice that the connection is closed, so we stop it and let its `ensure` close the connection.
+					def close_if_drained!
+						super
+						
+						if self.closed? and (reader = @reader) and !reader.current?
+							reader.stop
+						end
 					end
 					
 					# Start a transient background task that reads frames from the connection.
@@ -142,12 +158,14 @@ module Async
 					
 					# Can we use this connection to make requests?
 					def viable?
-						@stream&.readable?
+						!self.goaway_received? && @stream&.readable?
 					end
 					
 					# @returns [Boolean] Whether the connection can be reused.
+					#
+					# Once the remote peer has sent a GOAWAY frame, it will not process any new streams on this connection, so it must not be handed out for another request, even while the streams it accepted are still being drained.
 					def reusable?
-						!self.closed?
+						!self.closed? && !self.goaway_received?
 					end
 					
 					# @returns [String] The HTTP version string.

--- a/lib/async/http/protocol/http2/connection.rb
+++ b/lib/async/http/protocol/http2/connection.rb
@@ -87,13 +87,8 @@ module Async
 					end
 					
 					# Close the connection and stop the background reader.
-					#
-					# If the remote peer sent a graceful GOAWAY frame, the streams it accepted are still being processed and their responses are still on the way. Closing the connection now would fail those requests, even though the remote peer has already processed them. Instead we defer: the background reader closes the connection once the last stream completes. An explicit error still closes the connection immediately.
 					def close(error = nil)
 						if reader = @reader
-							# Only the background reader can drain the connection, so if it is not running, there is nothing to wait for:
-							return self if error.nil? and self.draining?
-							
 							@reader = nil
 							
 							# The reader task can close the connection itself, e.g. when the last stream completes and the connection is released back to the pool. Stopping it here would cancel the current task in the middle of this method, leaving the underlying stream open, so we let it unwind by itself: `closed?` is now true, so the read loop exits.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - HTTP/2 connections which received a graceful `GOAWAY` are no longer closed while the server is still answering the streams it accepted. Such a connection is retired from the pool, but stays open until the last accepted stream completes, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
+
 ## v0.101.0
 
   - Handle remote disconnects in `Async::HTTP::Protocol::HTTP1::Server#each` without reporting them as server failures.

--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - HTTP/2 connections which received a graceful `GOAWAY` are no longer closed while the server is still answering the streams it accepted. Such a connection is retired from the pool, but stays open until the last accepted stream completes, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
+  - HTTP/2 connections which received a graceful `GOAWAY` are removed from availability immediately, but remain in the pool until the server has finished answering the streams it accepted. The connection is closed after its final user releases it, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
 
 ## v0.101.0
 

--- a/test/async/http/protocol/http2/graceful_goaway.rb
+++ b/test/async/http/protocol/http2/graceful_goaway.rb
@@ -137,7 +137,6 @@ describe Async::HTTP::Protocol::HTTP2 do
 			
 			it "is closed" do
 				expect(connection).to be(:goaway_received?)
-				expect(connection).not.to be(:draining?)
 				expect(connection).to be(:closed?)
 			end
 			
@@ -163,7 +162,6 @@ describe Async::HTTP::Protocol::HTTP2 do
 			
 			it "is not offered to new requests" do
 				expect(connection).to be(:goaway_received?)
-				expect(connection).to be(:draining?)
 				expect(connection).not.to be(:closed?)
 				
 				expect(connection).not.to be(:reusable?)
@@ -176,25 +174,40 @@ describe Async::HTTP::Protocol::HTTP2 do
 				end.to raise_exception(::Protocol::HTTP::RefusedError)
 			end
 			
-			it "is not closed while the accepted stream is still in flight" do
-				Async do
-					connection.read_in_background
-					
-					# The pool retires a connection which is no longer reusable, but the stream the server accepted is still being processed, so the connection must stay open:
-					connection.close
-					
-					expect(connection).not.to be(:closed?)
-					expect(connection.streams).not.to be(:empty?)
-				ensure
-					connection.close(EOFError.new("Test finished!"))
-				end.wait
-			end
-			
-			it "is closed if there is no reader to drain it" do
+			it "closes synchronously" do
 				connection.close
 				
 				expect(connection).to be(:closed?)
 			end
+		end
+		
+		it "is retained by the pool until all users release it" do
+			connection.open!
+			pool = Async::Pool::Controller.wrap(limit: 1){connection}
+			
+			resource1 = pool.acquire
+			resource2 = pool.acquire
+			
+			response1 = connection.create_response
+			response2 = connection.create_response
+			connection.receive_goaway(goaway_frame(response2.stream.id))
+			
+			response1.stream.close!
+			pool.release(resource1)
+			
+			expect(pool.resources[connection]).to be == 1
+			expect(pool).not.to be(:available?)
+			expect(connection).not.to be(:closed?)
+			expect(connection.streams.keys).to be == [response2.stream.id]
+			
+			response2.stream.close!
+			expect(connection.framer).not.to be_nil
+			
+			pool.release(resource2)
+			
+			expect(pool.resources).not.to be(:key?, connection)
+			expect(connection.framer).to be_nil
+			expect(sockets.first).to be(:closed?)
 		end
 		
 		it "closes itself when the last drained stream completes on the sending side" do
@@ -214,7 +227,9 @@ describe Async::HTTP::Protocol::HTTP2 do
 			server.streams[stream.id].send_headers(response_headers, Protocol::HTTP2::END_STREAM)
 			
 			Async::Task.current.sleep(0.1)
-			expect(connection).to be(:draining?)
+			expect(connection).to be(:goaway_received?)
+			expect(connection).not.to be(:closed?)
+			expect(connection.streams.keys).to be == [stream.id]
 			
 			stream.send_data("body", Protocol::HTTP2::END_STREAM)
 			Async::Task.current.sleep(0.1)

--- a/test/async/http/protocol/http2/graceful_goaway.rb
+++ b/test/async/http/protocol/http2/graceful_goaway.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Denis Talakevich.
+
+require "async/http/client"
+require "async/http/mock"
+require "async/http/protocol/http2"
+require "protocol/http2/server"
+require "protocol/http2/stream"
+require "sus/fixtures/async/scheduler_context"
+
+require "async/queue"
+require "io/stream"
+require "socket"
+
+describe Async::HTTP::Protocol::HTTP2 do
+	include Sus::Fixtures::Async::SchedulerContext
+	
+	let(:response_headers) {[[":status", "200"]]}
+	
+	# A graceful GOAWAY is sent by the server *while it is still processing* the streams it
+	# accepted, which {Async::HTTP::Server} does not do, so these tests drive a raw HTTP/2 server
+	# over the sockets the mock endpoint hands out.
+	let(:peers) {Async::Queue.new}
+	let(:endpoint) {Async::HTTP::Mock::Endpoint.new(subject, "http", "localhost", queue: peers)}
+	let(:client) {Async::HTTP::Client.new(endpoint, limit: 1)}
+	
+	def goaway_frame(last_stream_id)
+		frame = Protocol::HTTP2::GoawayFrame.new
+		frame.pack(last_stream_id, 0, "")
+		
+		return frame
+	end
+	
+	def accept_connection(socket)
+		server = Protocol::HTTP2::Server.new(Protocol::HTTP2::Framer.new(socket))
+		server.read_connection_preface([])
+		
+		return server
+	end
+	
+	# Reads frames until `count` requests have arrived, and returns their streams in the order
+	# they were accepted.
+	def accept_requests(server, count)
+		streams = []
+		
+		while streams.size < count
+			frame = server.read_frame
+			
+			if frame.is_a?(Protocol::HTTP2::HeadersFrame)
+				streams << server.streams[frame.stream_id]
+			end
+		end
+		
+		return streams
+	end
+	
+	# The first connection accepts three requests but tells the client it only processed the
+	# first one; every later connection simply answers what it is given.
+	def handle_connection(socket, index, processed)
+		server = accept_connection(socket)
+		
+		if index == 1
+			streams = accept_requests(server, 3)
+			server.write_frame(goaway_frame(streams.first.id))
+			
+			# The response for the accepted stream arrives *after* the GOAWAY, exactly like nginx:
+			processed << streams.first.id
+			streams.first.send_headers(response_headers, Protocol::HTTP2::END_STREAM)
+		else
+			accept_requests(server, 2).each do |stream|
+				stream.send_headers(response_headers, Protocol::HTTP2::END_STREAM)
+			end
+		end
+		
+		# Keep the connection alive until the client closes it:
+		while true
+			server.read_frame
+		end
+	rescue EOFError, Errno::EPIPE
+		# The client closed the connection.
+	ensure
+		socket.close
+	end
+	
+	with "a server which sends a graceful GOAWAY" do
+		it "completes the requests the server accepted, and retries the rest" do
+			connections = 0
+			processed = []
+			
+			acceptor = Async(transient: true) do |task|
+				while socket = peers.dequeue
+					index = (connections += 1)
+					
+					task.async{handle_connection(socket, index, processed)}
+				end
+			end
+			
+			responses = 3.times.map do |index|
+				Async do
+					client.post("/#{index}", {}, ["body-#{index}"])
+				end
+			end.map(&:wait)
+			
+			# Every request completes, including the one which was in flight when the GOAWAY arrived:
+			expect(responses.map(&:status)).to be == [200, 200, 200]
+			
+			# The first request was answered on the connection which was going away:
+			expect(processed).to be == [1]
+			
+			# The two requests which the server did not process were retried on a new connection:
+			expect(connections).to be == 2
+		ensure
+			client.close
+			acceptor&.stop
+		end
+	end
+	
+	with "a connection which received a GOAWAY" do
+		let(:sockets) {::Socket.pair(::Socket::AF_UNIX, ::Socket::SOCK_STREAM)}
+		let(:connection) {Async::HTTP::Protocol::HTTP2::Client.new(IO::Stream(sockets.first))}
+		
+		def after(error = nil)
+			sockets.each{|socket| socket.close unless socket.closed?}
+			
+			super
+		end
+		
+		with "no streams left to drain" do
+			def before
+				super
+				
+				connection.open!
+				connection.receive_goaway(goaway_frame(0))
+			end
+			
+			it "is closed" do
+				expect(connection).to be(:goaway_received?)
+				expect(connection).not.to be(:draining?)
+				expect(connection).to be(:closed?)
+			end
+			
+			it "refuses new requests so that they are retried on another connection" do
+				# The connection is already closed, but the request was still not processed, so it must be refused rather than failed:
+				expect do
+					connection.call(::Protocol::HTTP::Request["POST", "/", {}, ["Hello World"]])
+				end.to raise_exception(::Protocol::HTTP::RefusedError)
+			end
+		end
+		
+		with "a stream still draining" do
+			def before
+				super
+				
+				connection.open!
+				
+				# One request is in flight, and the server tells us it is the last one it will process:
+				response = connection.create_response
+				
+				connection.receive_goaway(goaway_frame(response.stream.id))
+			end
+			
+			it "is not offered to new requests" do
+				expect(connection).to be(:goaway_received?)
+				expect(connection).to be(:draining?)
+				expect(connection).not.to be(:closed?)
+				
+				expect(connection).not.to be(:reusable?)
+				expect(connection).not.to be(:viable?)
+			end
+			
+			it "refuses new requests so that they are retried on another connection" do
+				expect do
+					connection.call(::Protocol::HTTP::Request["POST", "/", {}, ["Hello World"]])
+				end.to raise_exception(::Protocol::HTTP::RefusedError)
+			end
+			
+			it "is not closed while the accepted stream is still in flight" do
+				Async do
+					connection.read_in_background
+					
+					# The pool retires a connection which is no longer reusable, but the stream the server accepted is still being processed, so the connection must stay open:
+					connection.close
+					
+					expect(connection).not.to be(:closed?)
+					expect(connection.streams).not.to be(:empty?)
+				ensure
+					connection.close(EOFError.new("Test finished!"))
+				end.wait
+			end
+			
+			it "is closed if there is no reader to drain it" do
+				connection.close
+				
+				expect(connection).to be(:closed?)
+			end
+		end
+		
+		it "closes itself when the last drained stream completes on the sending side" do
+			server = Protocol::HTTP2::Server.new(Protocol::HTTP2::Framer.new(sockets.last))
+			server.open!
+			
+			connection.open!
+			
+			# The request body is still being written when the response arrives, so the stream is completed by this task rather than by the background reader:
+			stream = connection.create_stream
+			stream.send_headers([[":method", "POST"], [":path", "/"], [":authority", "localhost"]])
+			
+			connection.read_in_background
+			
+			server.read_frame
+			server.write_frame(goaway_frame(stream.id))
+			server.streams[stream.id].send_headers(response_headers, Protocol::HTTP2::END_STREAM)
+			
+			Async::Task.current.sleep(0.1)
+			expect(connection).to be(:draining?)
+			
+			stream.send_data("body", Protocol::HTTP2::END_STREAM)
+			Async::Task.current.sleep(0.1)
+			
+			expect(connection).to be(:closed?)
+			expect(connection.framer).to be_nil
+			expect(sockets.first).to be(:closed?)
+		end
+	end
+end


### PR DESCRIPTION
## Summary

When a server sends a graceful `GOAWAY` (error code `NO_ERROR`), it is telling us two things:
it will not accept new streams, **and** it is still processing the streams at or below
`last_stream_id` and will send their responses (RFC 9113 §6.8).

Today the client only honours the first half. `GOAWAY` closes the connection immediately, the
background reader stops reading, and every stream still waiting for a response is failed with:

```
EOFError: Connection closed with 15 active stream(s)!
```

Those streams are exactly the ones the server accepted and is about to answer. For a `POST`
this is unrecoverable: `Protocol::HTTP::Request#retry!` is `false` for non-idempotent methods,
so the request fails locally even though the server processed it and its side effects already
happened.

This is not an edge case. nginx sends a graceful `GOAWAY` on the `keepalive_requests`-th
request of every HTTP/2 connection (default `1000`), on `keepalive_time` (default `1h`), and on
every `nginx -s reload`. Any client that keeps a persistent HTTP/2 connection with requests in
flight loses a burst of them each time.

Together with socketry/protocol-http2#31 this makes the client drain such a connection: it is
retired from the pool immediately, but stays open until the streams the server accepted have
completed.

## Reproduction

Reproduced against real nginx 1.22.1 (and 1.20.2) with `async-http 0.101.0` +
`protocol-http2 0.26.2`. `keepalive_requests` is lowered to `40` so the event happens every 40
requests instead of every 1000; nothing else is unusual about the setup.

<details>
<summary><code>nginx.conf</code></summary>

```nginx
events {}
error_log /dev/stderr info;
http {
  keepalive_requests 40;
  log_format repro '$time_iso8601 status=$status';
  access_log /dev/stdout repro;
  upstream backend { server 127.0.0.1:8081; }
  server {
    listen 127.0.0.1:8443 http2;
    location / {
      proxy_pass http://backend;
      proxy_read_timeout 20;
    }
  }
}
```

</details>

<details>
<summary><code>backend.rb</code> — stands in for the application server: sleeps 300ms, answers 201, logs what it received and what it finished</summary>

```ruby
require 'socket'
require 'json'

server = TCPServer.new('127.0.0.1', 8081)
$stdout.sync = true

loop do
  socket = server.accept
  Thread.new(socket) do |s|
    head = +''
    head << s.readpartial(4096) until head.include?("\r\n\r\n")
    headers, rest = head.split("\r\n\r\n", 2)
    length = headers[/^content-length:\s*(\d+)/i, 1].to_i
    body = rest.b
    body << s.read(length - body.bytesize) while body.bytesize < length
    seq = JSON.parse(body)['seq']

    puts "recv seq=#{seq}"
    sleep 0.3
    s.write "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
    puts "done seq=#{seq}"
  ensure
    s.close rescue nil
  end
end
```

</details>

<details>
<summary><code>client.rb</code> — one persistent HTTP/2 connection, 4 bursts of 25 concurrent POSTs</summary>

```ruby
require 'async'
require 'async/http'
require 'json'

$stdout.sync = true

endpoint = Async::HTTP::Endpoint.parse('http://127.0.0.1:8443', protocol: Async::HTTP::Protocol::HTTP2)
client = Async::HTTP::Client.new(endpoint)

ok = []
failed = Hash.new{|h, k| h[k] = []}
seq = 0

Sync do |task|
  4.times do
    tasks = 25.times.map do
      seq += 1
      n = seq
      task.async do
        response = client.post('/', {'content-type' => 'application/json'}, [{seq: n}.to_json])
        response.read
        ok << n
      rescue => error
        failed["#{error.class}: #{error.message}"] << n
      end
    end
    tasks.each(&:wait)
    sleep 0.5
  end
ensure
  client.close
end

puts "ok=#{ok.size} failed=#{failed.values.sum(&:size)}"
failed.each{|message, seqs| puts "FAILED #{seqs.size}x #{message} seqs=#{seqs.sort.inspect}"}
```

</details>

```sh
docker run -d --name h2repro --network host -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" nginx:1.22.1
ruby backend.rb > backend.log 2>&1 &

bundle exec ruby client.rb
docker logs h2repro 2>&1 | grep -c 'status=499'   # requests the client hung up on
grep -c 'done seq' backend.log                    # requests the backend actually completed
```

### Before

```
ok=80 failed=20
FAILED 15x EOFError: Connection closed with 15 active stream(s)! seqs=[26, 27, ..., 40]
FAILED  5x EOFError: Connection closed with  5 active stream(s)! seqs=[76, 77, ..., 80]
nginx  201: 80  499: 20  'client prematurely closed connection': 2
backend received: 100  finished: 100
```

The failed sequence numbers are exactly the streams accepted before the 40th request on each
connection, and `backend finished: 100` shows every one of them was fully processed. nginx logs
them as `499` (client closed the connection) and, at `info` level,
`client prematurely closed connection while processing HTTP/2 connection`.

### After (this PR + socketry/protocol-http2#31)

```
ok=100 failed=0
nginx  201: 100  499: 0  'client prematurely closed connection': 0
backend received: 100  finished: 100
```

## What actually happens

1. nginx reaches `keepalive_requests` while opening stream `N`. It sets `h2c->goaway`, queues
   `GOAWAY(last_stream_id = N, NO_ERROR)`, and **still creates and processes stream `N`**.
   Later `HEADERS` frames on that connection are skipped without `RST_STREAM`, per RFC 9113
   §6.8. It only starts its lingering close once its in-flight stream count drops to zero.
   That is a textbook graceful shutdown.
2. `Protocol::HTTP2::Connection#receive_goaway` calls `close!`, so `closed?` becomes true right
   away.
3. The background reader loop is `while !self.closed?`, so it stops reading, and its `ensure`
   calls `Connection#close(nil)`. With streams still registered and no error given, that raises
   `EOFError.new("Connection closed with #{@streams.size} active stream(s)!")` into all of them
   and closes the socket.
4. The pool reaches the same outcome by a second path: each refused stream releases the
   connection, `reusable?` is false because the connection is closed, so the pool retires it —
   and `retire` calls `close`, killing whatever is still in flight.
5. `EOFError` is not retried for `POST`/`PATCH`, so the request surfaces as a failure.

The refusal half already works correctly: streams above `last_stream_id` are closed with
`Protocol::HTTP::RefusedError` and resent on a new connection. It is the accepted streams that
are lost.

## The fix

Server side (`protocol-http2`, socketry/protocol-http2#31): a graceful `GOAWAY` no longer
closes the connection while it still has accepted streams; the connection closes when the last
one completes. That PR adds `Connection#goaway_received?`; the remaining lifecycle is expressed
by the concrete `closed?` state and registered streams.

This PR is the client half:

- **`Connection#reusable?` / `#viable?`** are false once a `GOAWAY` has been received, so the
  pool retires the connection and never hands it to another request while it drains.
- **`Client#call`** raises `Protocol::HTTP::RefusedError` if a request does reach a connection
  which is going away (it can be acquired from the pool just before the `GOAWAY` arrives).
  Nothing has been written at that point, so the request is safely retried on a new connection,
  including non-idempotent ones. This is checked _before_ `closed?`, because a `GOAWAY` which
  finds no streams to drain closes the connection in the same step, and the pre-existing
  `Protocol::HTTP2::Error` raised for a closed connection is not retried.
- **async-pool 0.12 ownership** removes a non-reusable connection from availability immediately,
  but retains it while existing users remain. The final release retires and synchronously closes
  the connection. `Connection#close` therefore keeps its normal synchronous contract; graceful
  retention belongs to the pool rather than to a stateful close operation.
- **`Connection#close_if_drained!`** stops the background reader when the drain finishes in
  another task. The last drained stream can complete on the _sending_ side — the response
  arrived first and the request body was still being written — and the reader is then parked in
  a blocking read where it would never notice the connection is closed, leaking the task and
  the socket.
- **`Connection#close`** no longer stops the reader task when it _is_ the reader task. That
  path is now common — the last drained stream completes inside the reader, releases the
  connection, and the pool retires it — and `Async::Task#stop` on the current task raises
  `Async::Cancel` in the middle of `close`, so `super` never ran and the socket was left open.
  The reader unwinds on its own instead, since `closed?` is true by then.

## Tests

`test/async/http/protocol/http2/graceful_goaway.rb`:

- an end-to-end test with a raw HTTP/2 server that accepts three requests, sends
  `GOAWAY(last_stream_id = first)`, and only then answers the accepted one: all three requests
  succeed, the accepted one on the original connection and the other two retried on a new one;
- a connection which received `GOAWAY` is not reusable or viable and refuses new requests with
  `RefusedError`; a pool-level regression verifies that it is removed from availability after
  one release, retained while another user remains, and closed by the final release;
- a connection whose `GOAWAY` left nothing to drain still refuses new requests with
  `RefusedError` rather than failing them;
- a connection closes itself when the last drained stream completes on the sending side.

## Notes

- This depends on async-pool 0.12 and protocol-http2 0.27, both of which have been released.
- The same mechanism applies to any server that shuts a connection down gracefully — nginx
  `keepalive_requests` / `keepalive_time` / reload, and Envoy or gRPC servers, which send an
  advisory `GOAWAY(2^31-1)` first and the real `last_stream_id` later.

## Types of Changes

Bug fix

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).