### PR TITLE
Refuse requests assigned to closed HTTP/2 connections

### DIFF
--- a/lib/async/http/protocol/http2/client.rb
+++ b/lib/async/http/protocol/http2/client.rb
@@ -37,7 +37,8 @@ module Async
 						# The remote peer has sent a GOAWAY frame, so it will not process any new streams on this connection. The request has not been sent yet, so it is safe to retry it on a new connection, even if it is not idempotent. This is checked first, because a connection with no streams left to drain is closed by the GOAWAY itself.
 						raise ::Protocol::HTTP::RefusedError, "Connection is going away!" if self.goaway_received?
 						
-						raise ::Protocol::HTTP2::Error, "Connection closed!" if self.closed?
+						# The connection can close after being acquired from the pool. No stream has been created yet, so the request has not been written and is safe to retry.
+						raise ::Protocol::HTTP::RefusedError, "Connection closed!" if self.closed?
 						
 						response = create_response
 						write_request(response, request)

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - Requests assigned to an HTTP/2 connection which has already closed are refused before being written, allowing them to be retried safely.
   - HTTP/2 connections which received a graceful `GOAWAY` are removed from availability immediately, but remain in the pool until the server has finished answering the streams it accepted. The connection is closed after its final user releases it, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
 
 ## v0.101.0

--- a/test/async/http/protocol/http2/connection_close_with_active_streams.rb
+++ b/test/async/http/protocol/http2/connection_close_with_active_streams.rb
@@ -85,5 +85,17 @@ describe Async::HTTP::Protocol::HTTP2 do
 				expect(client_connection).to be(:closed?)
 			end.wait
 		end
+		
+		it "refuses a request when the connection is already closed" do
+			Async do
+				client_connection = Async::HTTP::Protocol::HTTP2::Client.new(client_stream)
+				client_connection.open!
+				client_connection.close
+				
+				expect do
+					client_connection.call(Protocol::HTTP::Request["POST", "/", {}, ["Hello"]])
+				end.to raise_exception(Protocol::HTTP::RefusedError)
+			end.wait
+		end
 	end
 end


### PR DESCRIPTION
## Summary

An HTTP/2 connection can close after the pool acquires it but before `Client#call` begins writing the request. At the existing `closed?` check, no response stream has been created and no request bytes have been written, so the request is known not to have been processed.

Raise `Protocol::HTTP::RefusedError` in this case so `Async::HTTP::Client` can safely retry the request, including non-idempotent requests with rewindable bodies.

HTTP/1 already has equivalent behavior in `Protocol::HTTP1::Connection#write_request`, which converts failures before a complete request is emitted into `Protocol::HTTP::RefusedError`.

## Tests

- Added coverage confirming that calling an already-closed HTTP/2 connection raises `Protocol::HTTP::RefusedError` for a POST request.
- `bundle exec bake test`: 256 passed, 3 skipped.

## Types of Changes

Bug fix

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the Developer Certificate of Origin 1.1.