### PR TITLE
Transfer proxy tunnel socket ownership

### DIFF
--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -50,8 +50,10 @@ module Async
 					@reader&.stop
 					@writer&.stop
 					
-					@tail&.close
-					@tail = nil
+					if tail = @tail
+						@tail = nil
+						tail.close
+					end
 				end
 				
 				private

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -29,15 +29,13 @@ module Async
 					task.async(transient: true, &self.method(:writer))
 				end
 				
+				# Transfer ownership of the tail socket to the caller. This method can only be called once; subsequent calls will raise an `IOError`.
 				# @returns [IO] The underlying IO object for the tail of the pipe.
 				def to_io
-					@tail
-				end
-				
-				# Transfer ownership of the tail socket to the caller so that it can be used and closed independently of the pipe's execution context.
-				# @returns [IO | Nil] The underlying IO object for the tail of the pipe, or `nil` if it has already been released.
-				def release
-					tail = @tail
+					unless tail = @tail
+						raise IOError, "The tail socket has already been transferred!"
+					end
+					
 					@tail = nil
 					return tail
 				end

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -11,21 +11,6 @@ module Async
 		module Body
 			# A bidirectional pipe that connects an input body to an output body using a Unix socket pair.
 			class Pipe
-				# Ensure the returned socket retains ownership of the pipe and closes it explicitly.
-				module OwnedSocket
-					# Close the owning pipe, or the underlying socket if ownership has already been released.
-					def close
-						if pipe = @async_http_pipe
-							@async_http_pipe = nil
-							pipe.close
-						else
-							super
-						end
-					end
-				end
-				
-				private_constant :OwnedSocket
-				
 				# If the input stream is closed first, it's likely the output stream will also be closed.
 				def initialize(input, output = Writable.new, task: Task.current)
 					@input = input
@@ -36,36 +21,37 @@ module Async
 					@head = ::IO::Stream(head)
 					@tail = tail
 					
-					# Capture the original close method so the pipe can close the socket without recursively invoking the ownership callback.
-					@close_tail = tail.method(:close)
-					
-					tail.extend(OwnedSocket)
-					tail.instance_variable_set(:@async_http_pipe, self)
-					
 					@reader = nil
 					@writer = nil
+					@closed = false
 					
 					task.async(transient: true, &self.method(:reader))
 					task.async(transient: true, &self.method(:writer))
 				end
 				
-				# The returned socket owns the pipe; closing it explicitly closes the forwarding tasks and both bodies.
 				# @returns [IO] The underlying IO object for the tail of the pipe.
 				def to_io
 					@tail
 				end
 				
+				# Transfer ownership of the tail socket to the caller so that it can be used and closed independently of the pipe's execution context.
+				# @returns [IO | Nil] The underlying IO object for the tail of the pipe, or `nil` if it has already been released.
+				def release
+					tail = @tail
+					@tail = nil
+					return tail
+				end
+				
 				# Close the pipe and stop the reader and writer tasks.
 				def close
-					if close_tail = @close_tail
-						@close_tail = nil
-						@tail.instance_variable_set(:@async_http_pipe, nil)
-						
-						@reader&.stop
-						@writer&.stop
-						
-						close_tail.call
-					end
+					return if @closed
+					@closed = true
+					
+					@reader&.stop
+					@writer&.stop
+					
+					@tail&.close
+					@tail = nil
 				end
 				
 				private

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -11,6 +11,21 @@ module Async
 		module Body
 			# A bidirectional pipe that connects an input body to an output body using a Unix socket pair.
 			class Pipe
+				# Ensure the returned socket retains ownership of the pipe and closes it explicitly.
+				module OwnedSocket
+					# Close the owning pipe, or the underlying socket if ownership has already been released.
+					def close
+						if pipe = @async_http_pipe
+							@async_http_pipe = nil
+							pipe.close
+						else
+							super
+						end
+					end
+				end
+				
+				private_constant :OwnedSocket
+				
 				# If the input stream is closed first, it's likely the output stream will also be closed.
 				def initialize(input, output = Writable.new, task: Task.current)
 					@input = input
@@ -21,6 +36,12 @@ module Async
 					@head = ::IO::Stream(head)
 					@tail = tail
 					
+					# Capture the original close method so the pipe can close the socket without recursively invoking the ownership callback.
+					@close_tail = tail.method(:close)
+					
+					tail.extend(OwnedSocket)
+					tail.instance_variable_set(:@async_http_pipe, self)
+					
 					@reader = nil
 					@writer = nil
 					
@@ -28,6 +49,7 @@ module Async
 					task.async(transient: true, &self.method(:writer))
 				end
 				
+				# The returned socket owns the pipe; closing it explicitly closes the forwarding tasks and both bodies.
 				# @returns [IO] The underlying IO object for the tail of the pipe.
 				def to_io
 					@tail
@@ -35,10 +57,15 @@ module Async
 				
 				# Close the pipe and stop the reader and writer tasks.
 				def close
-					@reader&.stop
-					@writer&.stop
-					
-					@tail.close
+					if close_tail = @close_tail
+						@close_tail = nil
+						@tail.instance_variable_set(:@async_http_pipe, nil)
+						
+						@reader&.stop
+						@writer&.stop
+						
+						close_tail.call
+					end
 				end
 				
 				private

--- a/lib/async/http/proxy.rb
+++ b/lib/async/http/proxy.rb
@@ -98,13 +98,18 @@ module Async
 				
 				if response.success?
 					pipe = Body::Pipe.new(response.body, input)
+					io = pipe.release
 					
-					return pipe.to_io unless block_given?
+					return io unless block_given?
 					
 					begin
-						yield pipe.to_io
+						yield io
 					ensure
-						pipe.close
+						begin
+							io.close
+						ensure
+							pipe.close
+						end
 					end
 				else
 					# This ensures we don't leave a response dangling:

--- a/lib/async/http/proxy.rb
+++ b/lib/async/http/proxy.rb
@@ -98,7 +98,7 @@ module Async
 				
 				if response.success?
 					pipe = Body::Pipe.new(response.body, input)
-					io = pipe.release
+					io = pipe.to_io
 					
 					return io unless block_given?
 					

--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - Closing the socket returned by `Async::HTTP::Body::Pipe` now explicitly closes the pipe and its forwarding tasks.
+  - Proxy tunnel sockets are no longer retained by their forwarding pipes, allowing the sockets to be closed or automatically collected independently of the Async context which created them.
   - Requests assigned to an HTTP/2 connection which has already closed are refused before being written, allowing them to be retried safely.
   - HTTP/2 connections which received a graceful `GOAWAY` are removed from availability immediately, but remain in the pool until the server has finished answering the streams it accepted. The connection is closed after its final user releases it, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
 

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - Closing the socket returned by `Async::HTTP::Body::Pipe` now explicitly closes the pipe and its forwarding tasks.
   - Requests assigned to an HTTP/2 connection which has already closed are refused before being written, allowing them to be retried safely.
   - HTTP/2 connections which received a graceful `GOAWAY` are removed from availability immediately, but remain in the pool until the server has finished answering the streams it accepted. The connection is closed after its final user releases it, so those requests no longer fail with `EOFError: Connection closed with N active stream(s)!`.
 

--- a/test/async/http/body/pipe.rb
+++ b/test/async/http/body/pipe.rb
@@ -10,7 +10,6 @@ require "async/http/body/writable"
 
 require "sus/fixtures/async"
 require "io/stream"
-require "openssl"
 
 describe Async::HTTP::Body::Pipe do
 	let(:input) {Async::HTTP::Body::Writable.new}
@@ -42,7 +41,8 @@ describe Async::HTTP::Body::Pipe do
 		end
 		
 		after do
-			io.close
+			io.close unless io.closed?
+			pipe.close
 		end
 		
 		it "returns an io socket" do
@@ -57,28 +57,30 @@ describe Async::HTTP::Body::Pipe do
 				expect(io.read).to be == data
 			end
 		end
+	end
+	
+	with "#release" do
+		include Sus::Fixtures::Async::ReactorContext
 		
-		with "an open pipe" do
-			let(:write_input) {false}
+		let(:io) {pipe.release}
+		
+		after do
+			io.close unless io.closed?
+			pipe.close
+		end
+		
+		it "transfers ownership of the socket" do
+			expect(io).to be_a(::Socket)
+			expect(pipe.to_io).to be_nil
+			expect(pipe.release).to be_nil
+		end
+		
+		it "observes the socket being closed from another thread" do
+			socket = io
+			Thread.new{socket.close}.value
 			
-			it "closes the pipe when closed" do
-				expect(input).not.to be(:closed?)
-				expect(output).not.to be(:closed?)
-				
-				io.close
-				
-				expect(input).to be(:closed?)
-				expect(output).to be(:closed?)
-			end
-			
-			it "closes the pipe through a TLS socket" do
-				tls = OpenSSL::SSL::SSLSocket.new(io, OpenSSL::SSL::SSLContext.new)
-				tls.sync_close = true
-				tls.close
-				
-				expect(input).to be(:closed?)
-				expect(output).to be(:closed?)
-			end
+			expect(output.read).to be_nil
+			expect(output).to be(:closed?)
 		end
 	end
 	

--- a/test/async/http/body/pipe.rb
+++ b/test/async/http/body/pipe.rb
@@ -10,29 +10,34 @@ require "async/http/body/writable"
 
 require "sus/fixtures/async"
 require "io/stream"
+require "openssl"
 
 describe Async::HTTP::Body::Pipe do
 	let(:input) {Async::HTTP::Body::Writable.new}
-	let(:pipe) {subject.new(input)}
+	let(:output) {Async::HTTP::Body::Writable.new}
+	let(:pipe) {subject.new(input, output)}
 	
 	let(:data) {"Hello World!"}
 	
 	with "#to_io" do
 		include Sus::Fixtures::Async::ReactorContext
 		
+		let(:write_input) {true}
 		let(:input_write_duration) {0}
 		let(:io) {pipe.to_io}
 		
 		def before
 			super
 			
-			# input writer task
-			Async do |task|
-				first, second = data.split(" ")
-				input.write("#{first} ")
-				sleep(input_write_duration) if input_write_duration > 0
-				input.write(second)
-				input.close_write
+			if write_input
+				# input writer task
+				Async do |task|
+					first, second = data.split(" ")
+					input.write("#{first} ")
+					sleep(input_write_duration) if input_write_duration > 0
+					input.write(second)
+					input.close_write
+				end
 			end
 		end
 		
@@ -52,6 +57,29 @@ describe Async::HTTP::Body::Pipe do
 				expect(io.read).to be == data
 			end
 		end
+		
+		with "an open pipe" do
+			let(:write_input) {false}
+			
+			it "closes the pipe when closed" do
+				expect(input).not.to be(:closed?)
+				expect(output).not.to be(:closed?)
+				
+				io.close
+				
+				expect(input).to be(:closed?)
+				expect(output).to be(:closed?)
+			end
+			
+			it "closes the pipe through a TLS socket" do
+				tls = OpenSSL::SSL::SSLSocket.new(io, OpenSSL::SSL::SSLContext.new)
+				tls.sync_close = true
+				tls.close
+				
+				expect(input).to be(:closed?)
+				expect(output).to be(:closed?)
+			end
+		end
 	end
 	
 	with "reactor going out of scope" do
@@ -63,6 +91,13 @@ describe Async::HTTP::Body::Pipe do
 		with "closed pipe" do
 			it "finishes" do
 				Async {pipe.close}
+			end
+			
+			it "can be closed more than once" do
+				Async do
+					pipe.close
+					pipe.close
+				end
 			end
 		end
 	end

--- a/test/async/http/body/pipe.rb
+++ b/test/async/http/body/pipe.rb
@@ -21,22 +21,19 @@ describe Async::HTTP::Body::Pipe do
 	with "#to_io" do
 		include Sus::Fixtures::Async::ReactorContext
 		
-		let(:write_input) {true}
 		let(:input_write_duration) {0}
 		let(:io) {pipe.to_io}
 		
 		def before
 			super
 			
-			if write_input
-				# input writer task
-				Async do |task|
-					first, second = data.split(" ")
-					input.write("#{first} ")
-					sleep(input_write_duration) if input_write_duration > 0
-					input.write(second)
-					input.close_write
-				end
+			# input writer task
+			Async do |task|
+				first, second = data.split(" ")
+				input.write("#{first} ")
+				sleep(input_write_duration) if input_write_duration > 0
+				input.write(second)
+				input.close_write
 			end
 		end
 		
@@ -50,29 +47,20 @@ describe Async::HTTP::Body::Pipe do
 			expect(io.read).to be == data
 		end
 		
+		it "can only transfer the socket once" do
+			io
+			
+			expect do
+				pipe.to_io
+			end.to raise_exception(IOError, message: be == "The tail socket has already been transferred!")
+		end
+		
 		with "blocking reads" do
 			let(:input_write_duration) {0.01}
 			
 			it "returns an io socket" do
 				expect(io.read).to be == data
 			end
-		end
-	end
-	
-	with "#release" do
-		include Sus::Fixtures::Async::ReactorContext
-		
-		let(:io) {pipe.release}
-		
-		after do
-			io.close unless io.closed?
-			pipe.close
-		end
-		
-		it "transfers ownership of the socket" do
-			expect(io).to be_a(::Socket)
-			expect(pipe.to_io).to be_nil
-			expect(pipe.release).to be_nil
 		end
 		
 		it "observes the socket being closed from another thread" do

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -89,9 +89,8 @@ AProxy = Sus::Shared("a proxy") do
 			
 			proxy.connect do |peer|
 				peer.write(data)
-				peer.close_write
 				
-				expect(peer.read).to be == data
+				expect(peer.read(data.bytesize)).to be == data
 			end
 			
 			proxy.close


### PR DESCRIPTION
## Summary

- make `Async::HTTP::Body::Pipe#to_io` a documented, one-shot transfer of the tail socket
- return an ordinary socket from `Proxy#connect`, with no callback or reference into its originating Async context
- explicitly close both the socket and forwarding pipe when `Proxy#connect` is used with a block
- verify that a second `to_io` call fails explicitly and that closure from another thread is observed through the socket pair
- document the lifecycle change in the unreleased notes

`Proxy#connect` returns an IO which may outlive or leave the thread or execution context that created it. Calling back into the pipe from `Socket#close` would therefore share mutable Async state across contexts, and Ruby IO autoclose does not invoke a Ruby-level `close` override.

`Body::Pipe#to_io` now transfers ownership and clears the pipe reference to the returned socket. It may only be called once; subsequent calls raise `IOError`. The caller exclusively owns that IO, so it can close normally or be automatically collected. The forwarding tasks observe EOF and write failures through the Unix socket pair and close their respective HTTP bodies. Cleanup is consequently eventual rather than an unsafe synchronous callback into the originating task.

The block form retains deterministic scoped cleanup because the proxy still owns both values for the duration of the block.

This complements #244: transient CONNECT tasks do not keep the creator alive, while the returned socket is not retained by those tasks.

## Verification

- `bundle exec sus test/async/http/body/pipe.rb test/async/http/proxy.rb` (34 passed)
- `bundle exec bake test` (259 passed, 3 skipped)
- `bundle exec rubocop` (135 files, no offenses)
- `COVERAGE=PartialSummary BUNDLE_WITH=maintenance bundle exec bake decode:index:coverage lib` (293/293)