### PR TITLE
Preserve orderly HTTP/2 duplex shutdown.

### DIFF
--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -55,8 +55,6 @@ module Async
 					end
 					
 					@head.close_write
-				rescue Async::Stop => error
-					raise
 				rescue => error
 				ensure
 					@input.close(error)

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -63,7 +63,7 @@ module Async
 				end
 				
 				# Read from the head of the pipe and write to the @output stream.
-				# If the @tail is closed, this will cause chunk to be nil, which in turn will call `@output.close` and `@head.close`
+				# A write-side close on @tail produces EOF here. A full close also stops the reader so both sides of the pipe can finish.
 				def writer(task)
 					@writer = task
 					
@@ -75,6 +75,10 @@ module Async
 				rescue => error
 				ensure
 					@output.close_write(error)
+
+					if @tail.closed?
+						@reader&.stop
+					end
 					
 					close_head if @reader&.finished?
 				end

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -75,7 +75,7 @@ module Async
 				rescue => error
 				ensure
 					@output.close_write(error)
-
+					
 					if @tail.closed?
 						@reader&.stop
 					end

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -63,8 +63,8 @@ module Async
 				end
 				
 				# Read from the head of the pipe and write to the @output stream.
-				# A write-side close on @tail produces EOF here. A full close also
-				# stops the reader so both sides of the pipe can finish.
+				# A write-side close on @tail produces EOF and closes @output
+				# independently of the input direction.
 				def writer(task)
 					@writer = task
 					
@@ -76,10 +76,6 @@ module Async
 				rescue => error
 				ensure
 					@output.close_write(error)
-					
-					if @tail.closed?
-						@reader&.stop
-					end
 					
 					close_head if @reader&.finished?
 				end

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -55,6 +55,8 @@ module Async
 					end
 					
 					@head.close_write
+				rescue Async::Stop => error
+					raise
 				rescue => error
 				ensure
 					@input.close(error)
@@ -63,7 +65,8 @@ module Async
 				end
 				
 				# Read from the head of the pipe and write to the @output stream.
-				# A write-side close on @tail produces EOF here. A full close also stops the reader so both sides of the pipe can finish.
+				# A write-side close on @tail produces EOF here. A full close also
+				# stops the reader so both sides of the pipe can finish.
 				def writer(task)
 					@writer = task
 					

--- a/lib/async/http/body/pipe.rb
+++ b/lib/async/http/body/pipe.rb
@@ -63,8 +63,7 @@ module Async
 				end
 				
 				# Read from the head of the pipe and write to the @output stream.
-				# A write-side close on @tail produces EOF and closes @output
-				# independently of the input direction.
+				# A write-side close on @tail produces EOF and closes @output independently of the input direction.
 				def writer(task)
 					@writer = task
 					

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -25,8 +25,10 @@ module Async
 					# @returns [String | Nil] The next chunk, or `nil` if the body is complete.
 					def read
 						if chunk = super
-							# If we read a chunk fron the stream, we want to extend the window if required so more data will be provided.
-							@stream.request_window_update
+							# If we read a chunk from the stream, we want to extend the window if required so more data will be provided.
+							if stream = @stream
+								stream.request_window_update
+							end
 						end
 						
 						# We track the expected length and check we got what we were expecting.
@@ -41,6 +43,17 @@ module Async
 						end
 						
 						return chunk
+					end
+					
+					# Close the input body and notify the stream that incoming data is no longer being consumed.
+					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
+					def close(error = nil)
+						super
+						
+						if stream = @stream
+							@stream = nil
+							stream.finish_input(self)
+						end
 					end
 				end
 			end

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -26,9 +26,7 @@ module Async
 					def read
 						if chunk = super
 							# If we read a chunk from the stream, we want to extend the window if required so more data will be provided.
-							if stream = @stream
-								stream.request_window_update
-							end
+							@stream&.request_window_update
 						end
 						
 						# We track the expected length and check we got what we were expecting.

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -43,7 +43,7 @@ module Async
 						return chunk
 					end
 					
-					# Close the input body and notify the stream that incoming data is no longer being consumed.
+					# Close the application-facing input body and notify the stream that incoming data is no longer being consumed. The HTTP/2 stream may remain open until local output has finished.
 					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
 					def close(error = nil)
 						super

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -43,14 +43,16 @@ module Async
 						return chunk
 					end
 					
-					# Close the application-facing input body and notify the stream that incoming data is no longer being consumed. The HTTP/2 stream may remain open until local output has finished.
+					# Close the application-facing input body and notify the stream that
+					# incoming data is no longer being consumed. The HTTP/2 stream may
+					# remain open until local output has finished.
 					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
 					def close(error = nil)
 						super
 						
 						if stream = @stream
 							@stream = nil
-							stream.finish_input(self)
+							stream.finish_input(self, error)
 						end
 					end
 				end

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -44,8 +44,8 @@ module Async
 					end
 					
 					# Close the application-facing input body and notify the stream that
-					# incoming data is no longer being consumed. The HTTP/2 stream may
-					# remain open until local output has finished.
+					# incoming data is no longer being consumed. The HTTP/2 stream remains
+					# open until the peer finishes unless its owner explicitly cancels it.
 					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
 					def close(error = nil)
 						super

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -43,10 +43,7 @@ module Async
 						return chunk
 					end
 					
-					# Close the application-facing input body and notify the stream that
-					# incoming data is no longer being consumed. While local output is
-					# active, the HTTP/2 stream remains open. Once output also closes, the
-					# remaining wire stream is terminated without an error.
+					# Close the application-facing input body and notify the stream that incoming data is no longer being consumed. While local output is active, the HTTP/2 stream remains open. Once output also closes, the remaining wire stream is terminated without an error.
 					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
 					def close(error = nil)
 						super

--- a/lib/async/http/protocol/http2/input.rb
+++ b/lib/async/http/protocol/http2/input.rb
@@ -44,8 +44,9 @@ module Async
 					end
 					
 					# Close the application-facing input body and notify the stream that
-					# incoming data is no longer being consumed. The HTTP/2 stream remains
-					# open until the peer finishes unless its owner explicitly cancels it.
+					# incoming data is no longer being consumed. While local output is
+					# active, the HTTP/2 stream remains open. Once output also closes, the
+					# remaining wire stream is terminated without an error.
 					# @parameter error [Exception | Nil] The error that caused the input to be closed, if any.
 					def close(error = nil)
 						super

--- a/lib/async/http/protocol/http2/output.rb
+++ b/lib/async/http/protocol/http2/output.rb
@@ -54,22 +54,24 @@ module Async
 					# @parameter chunk [String] The data to write.
 					def write(chunk)
 						until chunk.empty?
-							maximum_size = @stream.available_frame_size
+							stream = @stream or raise IOError, "HTTP/2 stream is closed!"
+							maximum_size = stream.available_frame_size
 							
 							# We try to avoid synchronization if possible:
 							if maximum_size <= 0
 								@guard.synchronize do
-									maximum_size = @stream.available_frame_size
+									maximum_size = stream.available_frame_size
 									
 									while maximum_size <= 0
 										@window_updated.wait(@guard)
 										
-										maximum_size = @stream.available_frame_size
+										stream = @stream or raise IOError, "HTTP/2 stream is closed!"
+										maximum_size = stream.available_frame_size
 									end
 								end
 							end
 							
-							break unless chunk = send_data(chunk, maximum_size)
+							break unless chunk = send_data(stream, chunk, maximum_size)
 						end
 					end
 					
@@ -93,6 +95,22 @@ module Async
 						if task = @task
 							@task = nil
 							task.stop(error)
+						end
+					end
+					
+					# Close the wire output without cancelling a streamable body. This
+					# allows bidirectional bodies to observe an orderly input closure and
+					# finish normally. A non-streaming producer has no input side through
+					# which closure can propagate, so it is stopped directly.
+					def close_stream
+						if @body.stream?
+							@stream = nil
+							
+							@guard.synchronize do
+								@window_updated.broadcast
+							end
+						else
+							stop(nil)
 						end
 					end
 					
@@ -137,11 +155,11 @@ module Async
 					# @param maximum_size [Integer] send up to this many bytes of data.
 					# @param stream [Stream] the stream to use for sending data frames.
 					# @return [String, nil] any data that could not be written.
-					def send_data(chunk, maximum_size)
+					def send_data(stream, chunk, maximum_size)
 						if chunk.bytesize <= maximum_size
-							@stream.send_data(chunk, maximum_size: maximum_size)
+							stream.send_data(chunk, maximum_size: maximum_size)
 						else
-							@stream.send_data(chunk.byteslice(0, maximum_size), maximum_size: maximum_size)
+							stream.send_data(chunk.byteslice(0, maximum_size), maximum_size: maximum_size)
 							
 							# The window was not big enough to send all the data, so we save it for next time:
 							return chunk.byteslice(maximum_size, chunk.bytesize - maximum_size)

--- a/lib/async/http/protocol/http2/output.rb
+++ b/lib/async/http/protocol/http2/output.rb
@@ -98,10 +98,7 @@ module Async
 						end
 					end
 					
-					# Close the wire output without cancelling a streamable body. This
-					# allows bidirectional bodies to observe an orderly input closure and
-					# finish normally. A non-streaming producer has no input side through
-					# which closure can propagate, so it is stopped directly.
+					# Close the wire output without cancelling a streamable body. This allows bidirectional bodies to observe an orderly input closure and finish normally. A non-streaming producer has no input side through which closure can propagate, so it is stopped directly.
 					def close_stream
 						if @body.stream?
 							@stream = nil

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -30,11 +30,13 @@ module Async
 						# Wait for the response headers and return the response body.
 						# @returns [Protocol::HTTP::Body::Readable | Nil] The response body.
 						def wait_for_input
+							response = @response
+							
 							# The input isn't ready until the response headers have been received:
-							@response.wait
+							response.wait
 							
 							# There is a possible race condition if you try to access @input - it might already be closed and nil.
-							return @response.body
+							return response.body
 						end
 						
 						# Handle a push promise stream from the server.
@@ -173,13 +175,12 @@ module Async
 					# still active, cancel the HTTP/2 exchange rather than draining it.
 					# @parameter error [Exception | Nil] The error which closed the response.
 					def close(error = nil)
-						body = @body
-						super
-						
-						if body && !@stream.closed?
+						if @body && !@stream.closed?
 							code = error ? ::Protocol::HTTP2::Error::INTERNAL_ERROR : ::Protocol::HTTP2::Error::CANCEL
 							@stream.send_reset_stream(code)
 						end
+						
+						super
 					end
 					
 					# @returns [Boolean] Whether the original request was a HEAD request.

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -171,8 +171,7 @@ module Async
 						@stream.wait
 					end
 					
-					# Close this response as quickly as possible. If the response body is
-					# still active, cancel the HTTP/2 exchange rather than draining it.
+					# Close this response as quickly as possible. If the response body is still active, cancel the HTTP/2 exchange rather than draining it.
 					# @parameter error [Exception | Nil] The error which closed the response.
 					def close(error = nil)
 						if @body && !@stream.closed?

--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -169,6 +169,19 @@ module Async
 						@stream.wait
 					end
 					
+					# Close this response as quickly as possible. If the response body is
+					# still active, cancel the HTTP/2 exchange rather than draining it.
+					# @parameter error [Exception | Nil] The error which closed the response.
+					def close(error = nil)
+						body = @body
+						super
+						
+						if body && !@stream.closed?
+							code = error ? ::Protocol::HTTP2::Error::INTERNAL_ERROR : ::Protocol::HTTP2::Error::CANCEL
+							@stream.send_reset_stream(code)
+						end
+					end
+					
 					# @returns [Boolean] Whether the original request was a HEAD request.
 					def head?
 						@request&.head?

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -28,19 +28,6 @@ module Async
 						@length = nil
 						@input = nil
 						
-						# Application input closure is independent of the HTTP/2 wire state:
-						#
-						# - Closing the input while local output remains active allows an
-						#   orderly bidirectional shutdown. A reset would also discard that
-						#   active output.
-						# - Incoming data is discarded and flow-control credit is restored to
-						#   preserve progress for bidirectional applications while local output
-						#   remains active.
-						# - If input is closed due to an error, or after local output has already
-						#   finished, the remaining remote half is abandoned and cancelled with
-						#   `RST_STREAM(CANCEL)`.
-						@input_abandoned = false
-						
 						# Output buffer, writing request body or response body (window_updated):
 						@output = nil
 					end
@@ -148,20 +135,19 @@ module Async
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 					end
 					
-					# Record that the application is no longer consuming incoming data.
-					# Preserve active local output during an orderly close, but arrange to
-					# cancel the remote half if the input was closed due to an error.
+					# Detach the application-facing input body from the wire stream.
+					# Incoming data will be discarded while maintaining flow control until
+					# the peer sends `END_STREAM`. Cancellation is an explicit operation
+					# performed by the request or response which owns the exchange.
 					# @parameter input [Input] The input body being closed.
 					# @parameter error [Exception | Nil] The error which closed the input.
 					def finish_input(input, error = nil)
 						if @input.equal?(input)
 							@input = nil
 							
-							if error || @state == :half_closed_local
-								@input_abandoned = true
+							if error
+								send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 							end
-							
-							close_if_finished
 						end
 					end
 					
@@ -203,20 +189,6 @@ module Async
 						return true
 					end
 					
-					# Send headers and check whether they completed the local side of the stream.
-					def send_headers(...)
-						result = super
-						close_if_finished
-						return result
-					end
-					
-					# Send data and check whether it completed the local side of the stream.
-					def send_data(...)
-						result = super
-						close_if_finished
-						return result
-					end
-					
 					# When the stream transitions to the closed state, this method is called. There are roughly two ways this can happen:
 					# - A frame is received which causes this stream to enter the closed state. This method will be invoked from the background reader task.
 					# - A frame is sent which causes this stream to enter the closed state. This method will be invoked from that task.
@@ -239,16 +211,6 @@ module Async
 						end
 						
 						return self
-					end
-					
-					private
-					
-					# Once local output has finished, cancel an abandoned remote half of
-					# the stream.
-					def close_if_finished
-						if @input_abandoned && @state == :half_closed_local
-							send_reset_stream(::Protocol::HTTP2::Error::CANCEL)
-						end
 					end
 				end
 			end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -27,6 +27,7 @@ module Async
 						# Input buffer, reading request body, or response body (receive_data):
 						@length = nil
 						@input = nil
+						@input_closed = false
 						
 						# Output buffer, writing request body or response body (window_updated):
 						@output = nil
@@ -114,14 +115,17 @@ module Async
 					def process_data(frame)
 						data = frame.unpack
 						
-						if @input
+						if input = @input
 							unless data.empty?
-								@input.write(data)
+								input.write(data)
 							end
 							
 							if frame.end_stream?
-								@input.close_write
+								input.close_write
 							end
+						else
+							# The application has closed the input, so discard incoming data while maintaining flow control for the stream.
+							request_window_update
 						end
 						
 						return data
@@ -129,6 +133,17 @@ module Async
 						raise
 					rescue # Anything else...
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
+					end
+					
+					# Called when the application is no longer consuming incoming data.
+					# @parameter input [Input] The input body being closed.
+					def finish_input(input)
+						if @input.equal?(input)
+							@input = nil
+							@input_closed = true
+							
+							close_if_finished
+						end
 					end
 					
 					# Set the body and begin sending it.
@@ -169,6 +184,20 @@ module Async
 						return true
 					end
 					
+					# Send headers and check whether they completed the local side of the stream.
+					def send_headers(...)
+						result = super
+						close_if_finished
+						return result
+					end
+					
+					# Send data and check whether it completed the local side of the stream.
+					def send_data(...)
+						result = super
+						close_if_finished
+						return result
+					end
+					
 					# When the stream transitions to the closed state, this method is called. There are roughly two ways this can happen:
 					# - A frame is received which causes this stream to enter the closed state. This method will be invoked from the background reader task.
 					# - A frame is sent which causes this stream to enter the closed state. This method will be invoked from that task.
@@ -191,6 +220,15 @@ module Async
 						end
 						
 						return self
+					end
+					
+					private
+					
+					# Once both application-facing directions are closed, cancel a stream whose remote side remains open.
+					def close_if_finished
+						if @input_closed && @state == :half_closed_local
+							send_reset_stream(::Protocol::HTTP2::Error::CANCEL)
+						end
 					end
 				end
 			end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -27,7 +27,14 @@ module Async
 						# Input buffer, reading request body, or response body (receive_data):
 						@length = nil
 						@input = nil
-						# `@input.nil?` can mean the input has not been prepared, the peer ended the stream without a body, or the stream has closed. Track explicit application closure separately.
+						
+						# `@input.nil?` does not tell us why input is absent:
+						#
+						# - The input has not been prepared yet.
+						# - The peer ended its sending side without a body.
+						# - The stream has already closed.
+						#
+						# `@input_closed` specifically records that the application explicitly closed the input while the peer may still be sending. This prevents a bodyless request from being cancelled before its response arrives.
 						@input_closed = false
 						
 						# Output buffer, writing request body or response body (window_updated):

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -27,6 +27,7 @@ module Async
 						# Input buffer, reading request body, or response body (receive_data):
 						@length = nil
 						@input = nil
+						# `@input.nil?` can mean the input has not been prepared, the peer ended the stream without a body, or the stream has closed. Track explicit application closure separately.
 						@input_closed = false
 						
 						# Output buffer, writing request body or response body (window_updated):

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -28,6 +28,12 @@ module Async
 						@length = nil
 						@input = nil
 						
+						# The application can close its input before the peer finishes sending.
+						# HTTP/2 cannot close only the receiving side of a stream, so incoming
+						# data is discarded until local output also finishes. At that point, a
+						# no-error reset terminates the remaining wire stream.
+						@input_closed = false
+						
 						# Output buffer, writing request body or response body (window_updated):
 						@output = nil
 					end
@@ -135,18 +141,21 @@ module Async
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 					end
 					
-					# Detach the application-facing input body from the wire stream.
-					# Incoming data will be discarded while maintaining flow control until
-					# the peer sends `END_STREAM`. Cancellation is an explicit operation
-					# performed by the request or response which owns the exchange.
+					# Close the application-facing receiving side of the stream. While local
+					# output remains active, incoming data is discarded with flow-control
+					# updates. Once local output is also closed, the remaining wire stream is
+					# terminated without an error.
 					# @parameter input [Input] The input body being closed.
 					# @parameter error [Exception | Nil] The error which closed the input.
 					def finish_input(input, error = nil)
 						if @input.equal?(input)
 							@input = nil
+							@input_closed = true
 							
 							if error
 								send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
+							else
+								close_if_finished
 							end
 						end
 					end
@@ -189,11 +198,32 @@ module Async
 						return true
 					end
 					
+					# Send headers and apply any pending application-side closure.
+					def send_headers(...)
+						result = super
+						close_if_finished
+						return result
+					end
+					
+					# Send data and apply any pending application-side closure.
+					def send_data(...)
+						result = super
+						close_if_finished
+						return result
+					end
+					
 					# When the stream transitions to the closed state, this method is called. There are roughly two ways this can happen:
 					# - A frame is received which causes this stream to enter the closed state. This method will be invoked from the background reader task.
 					# - A frame is sent which causes this stream to enter the closed state. This method will be invoked from that task.
 					# While the input stream is relatively straight forward, the output stream can trigger the second case above
 					def closed(error)
+						orderly_reset = error.is_a?(::Protocol::HTTP2::StreamError) &&
+							error.code == ::Protocol::HTTP2::Error::NO_ERROR
+						
+						if orderly_reset
+							error = nil
+						end
+						
 						super
 						
 						if input = @input
@@ -203,7 +233,12 @@ module Async
 						
 						if output = @output
 							@output = nil
-							output.stop(error)
+							
+							if orderly_reset
+								output.close_stream
+							else
+								output.stop(error)
+							end
 						end
 						
 						if pool = @pool and @connection
@@ -211,6 +246,16 @@ module Async
 						end
 						
 						return self
+					end
+					
+					private
+					
+					# If both application-facing directions are closed but the peer has not
+					# finished, terminate the remaining wire stream without an error.
+					def close_if_finished
+						if @input_closed && @state == :half_closed_local
+							send_reset_stream(::Protocol::HTTP2::Error::NO_ERROR)
+						end
 					end
 				end
 			end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -28,13 +28,11 @@ module Async
 						@length = nil
 						@input = nil
 						
-						# `@input.nil?` does not tell us why input is absent:
+						# Application input closure is independent of the HTTP/2 wire state:
 						#
-						# - The input has not been prepared yet.
-						# - The peer ended its sending side without a body.
-						# - The stream has already closed.
-						#
-						# `@input_closed` specifically records that the application explicitly closed the input while the peer may still be sending. This prevents a bodyless request from being cancelled before its response arrives.
+						# - Closing the input means the application will no longer consume incoming data, but it cannot immediately reset the stream because `RST_STREAM` would also close active local output.
+						# - Incoming data is discarded and flow-control credit is restored to preserve progress for bidirectional applications while local output remains active.
+						# - Once local output sends `END_STREAM`, the remaining remote half is cancelled with `RST_STREAM(CANCEL)` because neither application-facing direction remains in use.
 						@input_closed = false
 						
 						# Output buffer, writing request body or response body (window_updated):
@@ -143,7 +141,7 @@ module Async
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 					end
 					
-					# Called when the application is no longer consuming incoming data.
+					# Record that the application is no longer consuming incoming data and cancel the stream if local output has already finished.
 					# @parameter input [Input] The input body being closed.
 					def finish_input(input)
 						if @input.equal?(input)
@@ -232,7 +230,7 @@ module Async
 					
 					private
 					
-					# Once both application-facing directions are closed, cancel a stream whose remote side remains open.
+					# Once both application-facing directions are closed, cancel the remaining remote half of the stream.
 					def close_if_finished
 						if @input_closed && @state == :half_closed_local
 							send_reset_stream(::Protocol::HTTP2::Error::CANCEL)

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -30,10 +30,16 @@ module Async
 						
 						# Application input closure is independent of the HTTP/2 wire state:
 						#
-						# - Closing the input means the application will no longer consume incoming data, but it cannot immediately reset the stream because `RST_STREAM` would also close active local output.
-						# - Incoming data is discarded and flow-control credit is restored to preserve progress for bidirectional applications while local output remains active.
-						# - Once local output sends `END_STREAM`, the remaining remote half is cancelled with `RST_STREAM(CANCEL)` because neither application-facing direction remains in use.
-						@input_closed = false
+						# - Closing the input while local output remains active allows an
+						#   orderly bidirectional shutdown. A reset would also discard that
+						#   active output.
+						# - Incoming data is discarded and flow-control credit is restored to
+						#   preserve progress for bidirectional applications while local output
+						#   remains active.
+						# - If input is closed due to an error, or after local output has already
+						#   finished, the remaining remote half is abandoned and cancelled with
+						#   `RST_STREAM(CANCEL)`.
+						@input_abandoned = false
 						
 						# Output buffer, writing request body or response body (window_updated):
 						@output = nil
@@ -130,7 +136,8 @@ module Async
 								input.close_write
 							end
 						else
-							# The application has closed the input, so discard incoming data while maintaining flow control for the stream.
+							# The application has closed the input, so discard incoming data while
+							# maintaining flow control for the stream.
 							request_window_update
 						end
 						
@@ -141,12 +148,18 @@ module Async
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 					end
 					
-					# Record that the application is no longer consuming incoming data and cancel the stream if local output has already finished.
+					# Record that the application is no longer consuming incoming data.
+					# Preserve active local output during an orderly close, but arrange to
+					# cancel the remote half if the input was closed due to an error.
 					# @parameter input [Input] The input body being closed.
-					def finish_input(input)
+					# @parameter error [Exception | Nil] The error which closed the input.
+					def finish_input(input, error = nil)
 						if @input.equal?(input)
 							@input = nil
-							@input_closed = true
+							
+							if error || @state == :half_closed_local
+								@input_abandoned = true
+							end
 							
 							close_if_finished
 						end
@@ -230,9 +243,10 @@ module Async
 					
 					private
 					
-					# Once both application-facing directions are closed, cancel the remaining remote half of the stream.
+					# Once local output has finished, cancel an abandoned remote half of
+					# the stream.
 					def close_if_finished
-						if @input_closed && @state == :half_closed_local
+						if @input_abandoned && @state == :half_closed_local
 							send_reset_stream(::Protocol::HTTP2::Error::CANCEL)
 						end
 					end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -28,10 +28,7 @@ module Async
 						@length = nil
 						@input = nil
 						
-						# The application can close its input before the peer finishes sending.
-						# HTTP/2 cannot close only the receiving side of a stream, so incoming
-						# data is discarded until local output also finishes. At that point, a
-						# no-error reset terminates the remaining wire stream.
+						# The application can close its input before the peer finishes sending. HTTP/2 cannot close only the receiving side of a stream, so incoming data is discarded until local output also finishes. At that point, a no-error reset terminates the remaining wire stream.
 						@input_closed = false
 						
 						# Output buffer, writing request body or response body (window_updated):
@@ -129,8 +126,7 @@ module Async
 								input.close_write
 							end
 						else
-							# The application has closed the input, so discard incoming data while
-							# maintaining flow control for the stream.
+							# The application has closed the input, so discard incoming data while maintaining flow control for the stream.
 							request_window_update
 						end
 						
@@ -141,10 +137,7 @@ module Async
 						send_reset_stream(::Protocol::HTTP2::Error::INTERNAL_ERROR)
 					end
 					
-					# Close the application-facing receiving side of the stream. While local
-					# output remains active, incoming data is discarded with flow-control
-					# updates. Once local output is also closed, the remaining wire stream is
-					# terminated without an error.
+					# Close the application-facing receiving side of the stream. While local output remains active, incoming data is discarded with flow-control updates. Once local output is also closed, the remaining wire stream is terminated without an error.
 					# @parameter input [Input] The input body being closed.
 					# @parameter error [Exception | Nil] The error which closed the input.
 					def finish_input(input, error = nil)
@@ -250,8 +243,7 @@ module Async
 					
 					private
 					
-					# If both application-facing directions are closed but the peer has not
-					# finished, terminate the remaining wire stream without an error.
+					# If both application-facing directions are closed but the peer has not finished, terminate the remaining wire stream without an error.
 					def close_if_finished
 						if @input_closed && @state == :half_closed_local
 							send_reset_stream(::Protocol::HTTP2::Error::NO_ERROR)

--- a/test/async/http/protocol/http2.rb
+++ b/test/async/http/protocol/http2.rb
@@ -88,7 +88,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 					
 					reactor.async do |task|
 						begin
-							100.times do |i|
+							1000.times do |i|
 								body.write("Chunk #{i}")
 								sleep (0.01)
 							end
@@ -115,7 +115,9 @@ describe Async::HTTP::Protocol::HTTP2 do
 				
 				response.close
 				
-				notification.wait
+				Async::Task.current.with_timeout(1) do
+					notification.wait
+				end
 				
 				expect(response.stream.connection).to be(:reusable?)
 			end

--- a/test/async/http/protocol/http2.rb
+++ b/test/async/http/protocol/http2.rb
@@ -5,6 +5,7 @@
 
 require "async/http/protocol/http2"
 require "async/http/a_protocol"
+require "async/promise"
 
 describe Async::HTTP::Protocol::HTTP2 do
 	it_behaves_like Async::HTTP::AProtocol
@@ -80,7 +81,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 		end
 		
 		with "stopping requests" do
-			let(:notification) {Async::Notification.new}
+			let(:finished) {Async::Promise.new}
 			
 			let(:app) do
 				Protocol::HTTP::Middleware.for do |request|
@@ -96,7 +97,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 							# puts "Response generation failed: #{$!}"
 						ensure
 							body.close
-							notification.signal
+							finished.resolve(true)
 						end
 					end
 					
@@ -115,9 +116,7 @@ describe Async::HTTP::Protocol::HTTP2 do
 				
 				response.close
 				
-				Async::Task.current.with_timeout(1) do
-					notification.wait
-				end
+				finished.wait(timeout: 1)
 				
 				expect(response.stream.connection).to be(:reusable?)
 			end

--- a/test/async/http/protocol/http2/input.rb
+++ b/test/async/http/protocol/http2/input.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http2/input"
+
+describe Async::HTTP::Protocol::HTTP2::Input do
+	let(:stream) do
+		Class.new do
+			attr_reader :window_updates
+			attr_reader :finished_inputs
+			
+			def initialize
+				@window_updates = 0
+				@finished_inputs = []
+			end
+			
+			def request_window_update
+				@window_updates += 1
+			end
+			
+			def finish_input(input)
+				@finished_inputs << input
+			end
+		end.new
+	end
+	
+	let(:input) {subject.new(stream, nil)}
+	
+	it "requests a window update when data is consumed" do
+		input.write("Hello World")
+		
+		expect(input.read).to be == "Hello World"
+		expect(stream.window_updates).to be == 1
+	end
+	
+	it "notifies the stream when closed" do
+		error = RuntimeError.new("Input closed")
+		
+		input.close(error)
+		input.close
+		
+		expect(stream.finished_inputs).to be == [input]
+	end
+end

--- a/test/async/http/protocol/http2/input.rb
+++ b/test/async/http/protocol/http2/input.rb
@@ -20,8 +20,8 @@ describe Async::HTTP::Protocol::HTTP2::Input do
 				@window_updates += 1
 			end
 			
-			def finish_input(input)
-				@finished_inputs << input
+			def finish_input(input, error = nil)
+				@finished_inputs << [input, error]
 			end
 		end.new
 	end
@@ -41,6 +41,6 @@ describe Async::HTTP::Protocol::HTTP2::Input do
 		input.close(error)
 		input.close
 		
-		expect(stream.finished_inputs).to be == [input]
+		expect(stream.finished_inputs).to be == [[input, error]]
 	end
 end

--- a/test/async/http/protocol/http2/input_close.rb
+++ b/test/async/http/protocol/http2/input_close.rb
@@ -9,6 +9,37 @@ require "async/promise"
 require "sus/fixtures/async/http"
 
 describe Async::HTTP::Protocol::HTTP2 do
+	with "orderly bidirectional shutdown" do
+		include Sus::Fixtures::Async::HTTP::ServerContext
+		let(:protocol) {subject}
+		
+		let(:data) {"Hello World!"}
+		
+		let(:app) do
+			Protocol::HTTP::Middleware.for do |request|
+				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
+					stream.read(data.bytesize)
+					stream.write(data)
+				ensure
+					stream.close
+				end
+			end
+		end
+		
+		it "allows the peer to finish normally" do
+			input = Async::HTTP::Body::Writable.new
+			response = client.connect(authority: "localhost:1", body: input)
+			
+			input.write(data)
+			
+			expect(response.body.read).to be == data
+			expect(response.body.read).to be_nil
+		ensure
+			input&.close
+			response&.close
+		end
+	end
+	
 	with "closed input and active output" do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}

--- a/test/async/http/protocol/http2/input_close.rb
+++ b/test/async/http/protocol/http2/input_close.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http2"
+require "async/http/body/hijack"
+require "async/promise"
+require "sus/fixtures/async/http"
+
+describe Async::HTTP::Protocol::HTTP2 do
+	with "closed input and active output" do
+		include Sus::Fixtures::Async::HTTP::ServerContext
+		let(:protocol) {subject}
+		
+		let(:data) {"Hello World!"}
+		let(:request_body) {Async::Promise.new}
+		
+		let(:app) do
+			Protocol::HTTP::Middleware.for do |request|
+				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
+					stream.write("x" * 128 * 1024)
+					stream.flush
+					
+					request_body.resolve(stream.read(data.bytesize))
+				ensure
+					stream.close
+				end
+			end
+		end
+		
+		it "discards incoming data while continuing to write" do
+			input = Async::HTTP::Body::Writable.new
+			response = client.connect(authority: "localhost:1", body: input)
+			
+			response.body.close
+			input.write(data)
+			
+			current_task = Async::Task.current
+			received = current_task.with_timeout(1) do
+				request_body.wait
+			end
+			
+			expect(received).to be == data
+			input.close_write
+			
+			current_task.with_timeout(1) do
+				current_task.yield while client.pool.busy?
+			end
+			
+			expect(client.pool).not.to be(:busy?)
+		ensure
+			input&.close
+			response&.close
+		end
+	end
+end

--- a/test/async/http/protocol/http2/input_close.rb
+++ b/test/async/http/protocol/http2/input_close.rb
@@ -9,54 +9,6 @@ require "async/promise"
 require "sus/fixtures/async/http"
 
 describe Async::HTTP::Protocol::HTTP2 do
-	with "orderly bidirectional shutdown" do
-		include Sus::Fixtures::Async::HTTP::ServerContext
-		let(:protocol) {subject}
-		
-		let(:request_closed) {Async::Notification.new}
-		let(:finish_response) {Async::Notification.new}
-		
-		let(:app) do
-			Protocol::HTTP::Middleware.for do |request|
-				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
-					while stream.read_partial(1024)
-					end
-					
-					request_closed.signal
-					finish_response.wait
-				ensure
-					stream.close
-				end
-			end
-		end
-		
-		it "retains the stream until the peer finishes" do
-			input = Async::HTTP::Body::Writable.new
-			response = client.connect(authority: "localhost:1", body: input)
-			stream = Protocol::HTTP::Body::Stream.new(response.body, input)
-			
-			stream.close
-			
-			current_task = Async::Task.current
-			current_task.with_timeout(1) do
-				request_closed.wait
-			end
-			
-			expect(client.pool).to be(:busy?)
-			finish_response.signal
-			
-			current_task.with_timeout(1) do
-				current_task.yield while client.pool.busy?
-			end
-			
-			expect(client.pool).not.to be(:busy?)
-		ensure
-			finish_response.signal
-			stream&.close
-			response&.close
-		end
-	end
-	
 	with "closed input and active output" do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}

--- a/test/async/http/protocol/http2/input_close.rb
+++ b/test/async/http/protocol/http2/input_close.rb
@@ -13,29 +13,46 @@ describe Async::HTTP::Protocol::HTTP2 do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}
 		
-		let(:data) {"Hello World!"}
+		let(:request_closed) {Async::Notification.new}
+		let(:finish_response) {Async::Notification.new}
 		
 		let(:app) do
 			Protocol::HTTP::Middleware.for do |request|
 				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
-					stream.read(data.bytesize)
-					stream.write(data)
+					while stream.read_partial(1024)
+					end
+					
+					request_closed.signal
+					finish_response.wait
 				ensure
 					stream.close
 				end
 			end
 		end
 		
-		it "allows the peer to finish normally" do
+		it "retains the stream until the peer finishes" do
 			input = Async::HTTP::Body::Writable.new
 			response = client.connect(authority: "localhost:1", body: input)
+			stream = Protocol::HTTP::Body::Stream.new(response.body, input)
 			
-			input.write(data)
+			stream.close
 			
-			expect(response.body.read).to be == data
-			expect(response.body.read).to be_nil
+			current_task = Async::Task.current
+			current_task.with_timeout(1) do
+				request_closed.wait
+			end
+			
+			expect(client.pool).to be(:busy?)
+			finish_response.signal
+			
+			current_task.with_timeout(1) do
+				current_task.yield while client.pool.busy?
+			end
+			
+			expect(client.pool).not.to be(:busy?)
 		ensure
-			input&.close
+			finish_response.signal
+			stream&.close
 			response&.close
 		end
 	end

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -117,8 +117,8 @@ AProxy = Sus::Shared("a proxy") do
 	end
 	
 	with "idle tunnel" do
-		let(:request_closed) {Async::Notification.new}
-		let(:finish_response) {Async::Notification.new}
+		let(:request_closed) {Async::Promise.new}
+		let(:write_response) {Async::Promise.new}
 		
 		let(:app) do
 			Protocol::HTTP::Middleware.for do |request|
@@ -127,17 +127,19 @@ AProxy = Sus::Shared("a proxy") do
 						while stream.read_partial(1024)
 						end
 					ensure
-						request_closed.signal
+						request_closed.resolve(true)
 					end
 					
-					finish_response.wait
+					write_response.wait
+					stream.write("Hello World!")
+					stream.flush
 				ensure
 					stream.close
 				end
 			end
 		end
 		
-		it "releases the proxy connection when the peer is closed" do
+		it "releases the proxy connection when response data arrives after the peer is closed" do
 			proxy = Async::HTTP::Proxy.tcp(client, "localhost", 1)
 			peer = proxy.connect
 			
@@ -151,14 +153,17 @@ AProxy = Sus::Shared("a proxy") do
 				request_closed.wait
 			end
 			
+			expect(proxy.client.pool).to be(:busy?)
+			
+			write_response.resolve(true)
+			
 			current_task.with_timeout(1) do
 				current_task.yield while proxy.client.pool.busy?
 			end
 			
 			expect(proxy.client.pool).not.to be(:busy?)
-			finish_response.signal
 		ensure
-			finish_response.signal
+			write_response.resolve(true) unless write_response.resolved?
 			peer&.close
 			proxy&.close
 		end

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -117,6 +117,7 @@ AProxy = Sus::Shared("a proxy") do
 	end
 	
 	with "idle tunnel" do
+		let(:request_closed) {Async::Notification.new}
 		let(:finish_response) {Async::Notification.new}
 		
 		let(:app) do
@@ -125,6 +126,7 @@ AProxy = Sus::Shared("a proxy") do
 					while stream.read_partial(1024)
 					end
 					
+					request_closed.signal
 					finish_response.wait
 				ensure
 					stream.close
@@ -142,6 +144,12 @@ AProxy = Sus::Shared("a proxy") do
 			peer = nil
 			
 			current_task = Async::Task.current
+			current_task.with_timeout(1) do
+				request_closed.wait
+			end
+			
+			finish_response.signal
+			
 			current_task.with_timeout(1) do
 				current_task.yield while proxy.client.pool.busy?
 			end

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -123,10 +123,13 @@ AProxy = Sus::Shared("a proxy") do
 		let(:app) do
 			Protocol::HTTP::Middleware.for do |request|
 				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
-					while stream.read_partial(1024)
+					begin
+						while stream.read_partial(1024)
+						end
+					ensure
+						request_closed.signal
 					end
 					
-					request_closed.signal
 					finish_response.wait
 				ensure
 					stream.close
@@ -148,13 +151,12 @@ AProxy = Sus::Shared("a proxy") do
 				request_closed.wait
 			end
 			
-			finish_response.signal
-			
 			current_task.with_timeout(1) do
 				current_task.yield while proxy.client.pool.busy?
 			end
 			
 			expect(proxy.client.pool).not.to be(:busy?)
+			finish_response.signal
 		ensure
 			finish_response.signal
 			peer&.close

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -116,7 +116,7 @@ AProxy = Sus::Shared("a proxy") do
 		end
 	end
 	
-	with "idle tunnel" do
+	with "independent tunnel directions" do
 		let(:request_closed) {Async::Promise.new}
 		let(:write_response) {Async::Promise.new}
 		
@@ -139,7 +139,7 @@ AProxy = Sus::Shared("a proxy") do
 			end
 		end
 		
-		it "releases the proxy connection when response data arrives after the peer is closed" do
+		it "closes the response when forwarding to the closed peer fails" do
 			proxy = Async::HTTP::Proxy.tcp(client, "localhost", 1)
 			peer = proxy.connect
 			

--- a/test/async/http/proxy.rb
+++ b/test/async/http/proxy.rb
@@ -116,6 +116,44 @@ AProxy = Sus::Shared("a proxy") do
 		end
 	end
 	
+	with "idle tunnel" do
+		let(:finish_response) {Async::Notification.new}
+		
+		let(:app) do
+			Protocol::HTTP::Middleware.for do |request|
+				Async::HTTP::Body::Hijack.response(request, 200, {}) do |stream|
+					while stream.read_partial(1024)
+					end
+					
+					finish_response.wait
+				ensure
+					stream.close
+				end
+			end
+		end
+		
+		it "releases the proxy connection when the peer is closed" do
+			proxy = Async::HTTP::Proxy.tcp(client, "localhost", 1)
+			peer = proxy.connect
+			
+			expect(proxy.client.pool).to be(:busy?)
+			
+			peer.close
+			peer = nil
+			
+			current_task = Async::Task.current
+			current_task.with_timeout(1) do
+				current_task.yield while proxy.client.pool.busy?
+			end
+			
+			expect(proxy.client.pool).not.to be(:busy?)
+		ensure
+			finish_response.signal
+			peer&.close
+			proxy&.close
+		end
+	end
+	
 	with "proxied client" do
 		let(:app) do
 			Protocol::HTTP::Middleware.for do |request|

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -5,6 +5,7 @@
 
 require "async/http/protocol/http"
 require "protocol/http/body/streamable"
+require "async/promise"
 require "sus/fixtures/async/http"
 
 AnEchoServer = Sus::Shared("an echo server") do
@@ -122,6 +123,50 @@ AnEchoClient = Sus::Shared("an echo client") do
 	end
 end
 
+AClosingServer = Sus::Shared("a closing server") do
+	let(:data) {"Hello World!"}
+	let(:finished) {Async::Promise.new}
+	
+	let(:app) do
+		::Protocol::HTTP::Middleware.for do |request|
+			streamable = ::Protocol::HTTP::Body::Streamable.response(request) do |stream|
+				stream.write(stream.read(data.bytesize))
+				stream.flush
+				
+				while stream.read_partial(1024)
+				end
+				
+				finished.resolve(true)
+			ensure
+				stream.close
+			end
+			
+			::Protocol::HTTP::Response[200, {}, streamable]
+		end
+	end
+	
+	it "should finish normally when the peer closes" do
+		output = ::Protocol::HTTP::Body::Writable.new
+		response = client.post("/", body: output)
+		stream = ::Protocol::HTTP::Body::Stream.new(response.body, output)
+		
+		stream.write(data)
+		expect(stream.read(data.bytesize)).to be == data
+		
+		stream.close
+		stream = nil
+		
+		result = Async::Task.current.with_timeout(1) do
+			finished.wait
+		end
+		
+		expect(result).to be == true
+	ensure
+		stream&.close
+		response&.close
+	end
+end
+
 [Async::HTTP::Protocol::HTTP1, Async::HTTP::Protocol::HTTP2].each do |protocol|
 	describe protocol, unique: protocol.name do
 		include Sus::Fixtures::Async::HTTP::ServerContext
@@ -130,5 +175,6 @@ end
 		
 		it_behaves_like AnEchoServer
 		it_behaves_like AnEchoClient
+		it_behaves_like AClosingServer
 	end
 end


### PR DESCRIPTION
Align HTTP/2 application-facing input and output closure with HTTP/1 and duplex stream semantics.

- The input and output directions close independently. Ending local output does not implicitly cancel remote input.
- Closing an HTTP/2 input marks the application receive side as closed. Incoming DATA is discarded while restoring flow-control credit as long as local output remains active.
- Once both application-facing directions are closed, the remaining wire stream is terminated with RST_STREAM(NO_ERROR) rather than treating normal closure as cancellation.
- A received NO_ERROR reset is treated as orderly closure. Streamable bodies observe input EOF and unwind normally instead of having their task cancelled.
- Closing the owning HTTP/2 response remains an explicit fast cancellation and sends RST_STREAM(CANCEL) while its body is active. Input errors use INTERNAL_ERROR.
- Body::Pipe preserves the same independent-direction model: closing its write side closes the HTTP output without opportunistically stopping HTTP input.

The tests cover these contracts at their semantic boundaries:

- Shared proxy behavior verifies under HTTP/1.0, HTTP/1.1, and HTTP/2 that closing the local peer finishes the request direction while an idle response remains active. If later response data cannot be forwarded to the closed peer, the response direction closes and the pooled resource is released.
- Shared streamable-body behavior verifies under HTTP/1 and HTTP/2 that an echo completes and the server streaming block exits normally when its peer closes. This captures the same lifecycle required by async-websocket without depending on WebSocket framing.
- HTTP/2-specific coverage confirms that closing input while output remains active discards incoming data without blocking the opposite direction.

## Testing

- Full async-http suite: 264 passed, 3 skipped, 32,919 assertions.
- Focused proxy suite: 30 passed, 84 assertions.
- Focused pipe suite: 4 passed, 3 assertions.
- RuboCop over all tracked Ruby files: 120 files inspected, no offenses.
- `git diff --check`: clean.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the Developer Certificate of Origin 1.1.
