### PR TITLE
Support orderly HTTP/2 `NO_ERROR` resets.

### DIFF
--- a/lib/async/http/protocol/http2/response.rb
+++ b/lib/async/http/protocol/http2/response.rb
@@ -129,10 +129,9 @@ module Async
 								@response = nil
 							end
 							
-							if error
+							unless @ready.resolved?
+								error ||= EOFError.new("Stream closed before response headers were received!")
 								@ready.reject(error)
-							else
-								@ready.resolve(nil)
 							end
 						end
 					end

--- a/lib/async/http/protocol/http2/stream.rb
+++ b/lib/async/http/protocol/http2/stream.rb
@@ -210,10 +210,7 @@ module Async
 					# - A frame is sent which causes this stream to enter the closed state. This method will be invoked from that task.
 					# While the input stream is relatively straight forward, the output stream can trigger the second case above
 					def closed(error)
-						orderly_reset = error.is_a?(::Protocol::HTTP2::StreamError) &&
-							error.code == ::Protocol::HTTP2::Error::NO_ERROR
-						
-						if orderly_reset
+						if error.is_a?(::Protocol::HTTP2::StreamError) && error.code == ::Protocol::HTTP2::Error::NO_ERROR
 							error = nil
 						end
 						
@@ -227,10 +224,10 @@ module Async
 						if output = @output
 							@output = nil
 							
-							if orderly_reset
-								output.close_stream
-							else
+							if error
 								output.stop(error)
+							else
+								output.close_stream
 							end
 						end
 						

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Handle `RST_STREAM(NO_ERROR)` as an orderly HTTP/2 stream closure while still failing requests whose streams close before any response headers are received.
+
 ## v0.102.0
 
   - Requests assigned to an HTTP/2 connection which has already closed are refused before being written, allowing them to be retried safely.

--- a/test/async/http/protocol/http2/connection_close_with_active_streams.rb
+++ b/test/async/http/protocol/http2/connection_close_with_active_streams.rb
@@ -69,6 +69,20 @@ describe Async::HTTP::Protocol::HTTP2 do
 			end.wait
 		end
 		
+		it "raises EOFError when the stream closes before receiving headers" do
+			Async do
+				client_connection = Async::HTTP::Protocol::HTTP2::Client.new(client_stream)
+				client_connection.open!
+				
+				response = client_connection.create_response
+				response.stream.close!
+				
+				expect do
+					client_connection.read_response(response)
+				end.to raise_exception(EOFError, message: be =~ /Stream closed before response headers/)
+			end.wait
+		end
+		
 		it "does not raise error when connection closes without active streams" do
 			Async do |task|
 				# Create client connection

--- a/test/async/http/protocol/http2/response_close_on_stream_error.rb
+++ b/test/async/http/protocol/http2/response_close_on_stream_error.rb
@@ -10,7 +10,7 @@ require "sus/fixtures/async/http"
 require "protocol/http/body/wrapper"
 
 describe Async::HTTP::Protocol::HTTP2 do
-	with "response body close on stream error" do
+	with "response body close on stream reset" do
 		include Sus::Fixtures::Async::HTTP::ServerContext
 		let(:protocol) {subject}
 		

--- a/test/async/http/protocol/http2/stream.rb
+++ b/test/async/http/protocol/http2/stream.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "async/http/protocol/http2/stream"
+
+describe Async::HTTP::Protocol::HTTP2::Stream do
+	let(:output) do
+		Class.new do
+			def close_stream
+			end
+			
+			def stop(error)
+			end
+		end.new
+	end
+	
+	let(:stream) do
+		Class.new(subject) do
+			def initialize(output)
+				@input = nil
+				@output = output
+				@pool = nil
+				@connection = nil
+			end
+		end.new(output)
+	end
+	
+	it "closes the output stream on an orderly closure" do
+		expect(output).to receive(:close_stream)
+		
+		stream.closed(nil)
+	end
+	
+	it "stops the output stream on an error" do
+		error = RuntimeError.new("Stream failed!")
+		expect(output).to receive(:stop).with(error)
+		
+		stream.closed(error)
+	end
+end


### PR DESCRIPTION
## Summary

- Treat both `closed(nil)` and the legacy `StreamError(NO_ERROR)` callback as orderly HTTP/2 stream closure.
- Close streamable output normally for orderly closure and stop it with the exception for actual errors.
- Reject responses whose streams close before response headers are received.
- Add coverage for orderly output closure, error propagation, and pre-header closure.

## Rationale

This provides compatibility with socketry/protocol-http2#32, which represents `RST_STREAM(NO_ERROR)` explicitly as `closed(nil)`, while retaining compatibility with protocol-http2 0.27.0. A stream closed before receiving response headers is still an incomplete response and must fail rather than resolve successfully.

## Testing

- Full test suite: 267 passed, 3 skipped.
- Focused HTTP/2 tests pass with protocol-http2 0.27.0 and the branch from socketry/protocol-http2#32.
- `bundle exec rubocop`: 140 files, no offenses.
- `bundle exec bake decode:index:coverage lib`: 299/299 definitions documented.